### PR TITLE
Add unit tests with 100% coverage (mocked Skedda API)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/**/coverage.cobertura.xml

--- a/TennisBooking.sln
+++ b/TennisBooking.sln
@@ -4,6 +4,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{3D084251-DB1
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TennisBooking", "src\TennisBooking\TennisBooking.csproj", "{FC022931-FF15-4167-A794-DFBE05EAB2DC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TennisBooking.Tests", "tests\TennisBooking.Tests\TennisBooking.Tests.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +18,13 @@ Global
 		{FC022931-FF15-4167-A794-DFBE05EAB2DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC022931-FF15-4167-A794-DFBE05EAB2DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FC022931-FF15-4167-A794-DFBE05EAB2DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FC022931-FF15-4167-A794-DFBE05EAB2DC} = {3D084251-DB13-40CE-BBD7-D0065EB6FFA6}
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 EndGlobal

--- a/src/TennisBooking/Program.cs
+++ b/src/TennisBooking/Program.cs
@@ -16,11 +16,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddEnvironmentVariables();
 var skeddaConfig = builder.Configuration.GetSection("SkeddaConfig");
 builder.Services.Configure<SkeddaOptions>(skeddaConfig);
-builder.Services.AddHttpClient<BookingService>(client => {
-    var opts = skeddaConfig.Get<SkeddaOptions>();
-    client.BaseAddress = new Uri(opts.ApiBaseUrl);
-});
 builder.Services.AddHttpClient<TelegramService>();
+builder.Services.AddScoped<ISkeddaApiClient, SkeddaApiClient>();
 
 var connString = builder.Configuration.GetConnectionString("Default")
                  ?? throw new InvalidOperationException("Connection string 'Default' not found.");

--- a/src/TennisBooking/Services/BookingService.cs
+++ b/src/TennisBooking/Services/BookingService.cs
@@ -1,165 +1,130 @@
-﻿namespace TennisBooking.Services;
+namespace TennisBooking.Services;
 
 using System.Globalization;
 using Models;
 using Hangfire;
 using DAL.Models;
-using System.Text.RegularExpressions;
-using System.Net;
 using Microsoft.Extensions.Logging;
 using Options;
-using System.Text;
-using Newtonsoft.Json;
 using Microsoft.Extensions.Options;
 
-public class BookingService {
-    private const string AccountLoginPath = "/account/login";
-    private const string LoginPath = "/logins";
-    private const string GetBookingsPath = "/booking";
-    private const string BookingPath = "/bookings";
-    private const string CsrfHeaderName = "x-skedda-requestverificationtoken";
-    private const string CookieHeaderName = "Cookie";
-    private const string ApplicationCookieName = "X-Skedda-ApplicationCookie";
-    private const string CsrfCookieName = "X-Skedda-RequestVerificationCookie";
+public class BookingService
+{
     private readonly ILogger<BookingService> _logger;
     private readonly SkeddaOptions _opts;
     private readonly IBackgroundJobClient _backgroundJobClient;
     private readonly TelegramService _telegram;
+    private readonly ISkeddaApiClient _skeddaApiClient;
 
     public BookingService(
         ILogger<BookingService> logger,
         IOptions<SkeddaOptions> opts,
         TelegramService telegram,
-        IBackgroundJobClient backgroundJobClient) {
+        IBackgroundJobClient backgroundJobClient,
+        ISkeddaApiClient skeddaApiClient)
+    {
         _logger = logger;
         _opts = opts.Value;
         _backgroundJobClient = backgroundJobClient;
         _telegram = telegram;
+        _skeddaApiClient = skeddaApiClient;
     }
 
-    public async Task Preparation(UserConfig userConfig, bool scheduleBookingJob, CancellationToken ct) {
-        if (userConfig == null) {
+    public virtual async Task Preparation(UserConfig userConfig, bool scheduleBookingJob, CancellationToken ct)
+    {
+        if (userConfig == null)
+        {
             _logger.LogError("UserConfig is null");
             return;
         }
+
         var bookingDay = DateTimeOffset.UtcNow.AddDays(14);
         var tz = TimeZoneInfo.FindSystemTimeZoneById("Europe/Kyiv");
-        var startTime = new DateTimeOffset(bookingDay.Year, bookingDay.Month, bookingDay.Day, userConfig.Hour, 0, 0, 0, tz.GetUtcOffset(bookingDay));
-        try {
-            var handler = new HttpClientHandler { CookieContainer = new CookieContainer() };
-            var baseUri = new Uri(_opts.ApiBaseUrl);
-            using var client = new HttpClient(handler) { BaseAddress = baseUri };
+        var startTime = new DateTimeOffset(bookingDay.Year, bookingDay.Month, bookingDay.Day,
+            userConfig.Hour, 0, 0, 0, tz.GetUtcOffset(bookingDay));
 
-            var openLoginPage = await client.GetAsync(AccountLoginPath, ct);
-            openLoginPage.EnsureSuccessStatusCode();
-            var loginHtml = await openLoginPage.Content.ReadAsStringAsync(ct);
-            var requestVerificationToken = GetRequestVerificationToken(loginHtml);
-            var loginReq = new HttpRequestMessage(HttpMethod.Post, LoginPath);
-            loginReq.Headers.Add(CsrfHeaderName, requestVerificationToken);
-            loginReq.Headers.Add(CookieHeaderName,
-                $"{CsrfCookieName}={handler.CookieContainer.GetCookies(baseUri)[CsrfCookieName].Value}");
+        try
+        {
+            var session = await _skeddaApiClient.LoginAndGetSessionAsync(
+                userConfig.Username, userConfig.Password, ct);
 
-            loginReq.Content = new StringContent(
-                JsonConvert.SerializeObject(new {
-                    login = new {
-                        arbitraryerrors = (object)null,
-                        username = userConfig.Username,
-                        password = userConfig.Password,
-                        rememberMe = false
-                    }
-                }),
-                Encoding.UTF8,
-                "application/json"
-            );
-            var loginResp = await client.SendAsync(loginReq, ct);
-            loginResp.EnsureSuccessStatusCode();
-
-            var csrfCookie = handler.CookieContainer.GetCookies(baseUri)[CsrfCookieName].Value;
-
-            var applicationCookie = handler.CookieContainer.GetCookies(baseUri)[ApplicationCookieName].Value;
-            var getBookingsReq = new HttpRequestMessage(HttpMethod.Get, GetBookingsPath);
-            getBookingsReq.Headers.Add(CsrfHeaderName, requestVerificationToken);
-            getBookingsReq.Headers.Add(CookieHeaderName,
-                $"{CsrfCookieName}={csrfCookie}; " +
-                $"{ApplicationCookieName}={applicationCookie}");
-            var getBookingsResp = await client.SendAsync(getBookingsReq, ct);
-            getBookingsResp.EnsureSuccessStatusCode();
-            requestVerificationToken = GetRequestVerificationToken(await getBookingsResp.Content.ReadAsStringAsync(ct));
-
-            var bookingBody = new {
-                booking = new {
+            var bookingBody = new
+            {
+                booking = new
+                {
                     addConference = false,
                     allowInviteOthers = false,
-                    arbitraryerrors = (object)null,
-                    attendees = new int[0],
+                    arbitraryerrors = (object?)null,
+                    attendees = Array.Empty<int>(),
                     availabilityStatus = 1,
-                    chargeTransactionId = (object)null,
-                    checkInAudits = (object)null,
-                    createdDate = (object)null,
-                    customFields = new int[0],
-                    decoupleBooking = (object)null,
-                    decoupleDate = (object)null,
+                    chargeTransactionId = (object?)null,
+                    checkInAudits = (object?)null,
+                    createdDate = (object?)null,
+                    customFields = Array.Empty<int>(),
+                    decoupleBooking = (object?)null,
+                    decoupleDate = (object?)null,
                     end = startTime.AddHours(1).ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture),
-                    endOfLastOccurrence = (object)null,
+                    endOfLastOccurrence = (object?)null,
                     hideAttendees = true,
                     lockInMargin = 1,
                     paymentStatus = 0,
-                    piId = (object)null,
+                    piId = (object?)null,
                     price = 0,
-                    recurrenceRule = (object)null,
+                    recurrenceRule = (object?)null,
                     spaces = new[] { userConfig.ResourceId },
                     start = startTime.ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture),
                     stripPrivateEventDetails = false,
-                    syncType = (object)null,
-                    title = (object)null,
+                    syncType = (object?)null,
+                    title = (object?)null,
                     type = 1,
                     unrecognizedOrganizer = false,
                     venue = userConfig.Venue,
                     venueuser = userConfig.VenueUser
                 }
             };
-            var bookingInfo = new BookingInfo {
+
+            var bookingInfo = new BookingInfo
+            {
                 UserConfig = userConfig,
                 Body = bookingBody,
-                RequestVerificationToken = requestVerificationToken,
-                CsrfCookie = csrfCookie,
-                ApplicationCookie = applicationCookie,
+                RequestVerificationToken = session.RequestVerificationToken,
+                CsrfCookie = session.CsrfCookie,
+                ApplicationCookie = session.ApplicationCookie,
                 StartTime = startTime,
             };
-            if (scheduleBookingJob) {
-                _backgroundJobClient.Schedule<BookingService>(x => x.Booking(bookingInfo, ct), startTime.AddDays(-14));
+
+            if (scheduleBookingJob)
+            {
+                _backgroundJobClient.Schedule<BookingService>(
+                    x => x.Booking(bookingInfo, ct), startTime.AddDays(-14));
             }
         }
-        catch (Exception ex) {
+        catch (Exception ex)
+        {
             _logger.LogError(ex, "Failed to book court for user {ConfigId}", userConfig.Username);
             throw;
         }
     }
 
-    public async Task Booking(BookingInfo bookingInfo, CancellationToken ct) {
-        if (bookingInfo == null) {
+    public virtual async Task Booking(BookingInfo bookingInfo, CancellationToken ct)
+    {
+        if (bookingInfo == null)
+        {
             _logger.LogError("BookingInfo is null");
             return;
         }
-        try {
-            var baseUri = new Uri(_opts.ApiBaseUrl);
-            using var client = new HttpClient { BaseAddress = baseUri };
 
-            var bookReq = new HttpRequestMessage(HttpMethod.Post, BookingPath);
-            bookReq.Content = new StringContent(
-                JsonConvert.SerializeObject(bookingInfo.Body),
-                Encoding.UTF8,
-                "application/json"
-            );
-            bookReq.Headers.Add(CsrfHeaderName, bookingInfo.RequestVerificationToken);
-            bookReq.Headers.Add(CookieHeaderName,
-                $"{CsrfCookieName}={bookingInfo.CsrfCookie}; " +
-                $"{ApplicationCookieName}={bookingInfo.ApplicationCookie}");
-            var bookResp = await client.SendAsync(bookReq, ct);
-            if (!bookResp.IsSuccessStatusCode) {
-                throw new HttpRequestException($"Response from Skedda {await bookResp.Content.ReadAsStringAsync()}");
-            }
-            bookResp.EnsureSuccessStatusCode();
+        try
+        {
+            var session = new SkeddaSession
+            {
+                RequestVerificationToken = bookingInfo.RequestVerificationToken,
+                CsrfCookie = bookingInfo.CsrfCookie,
+                ApplicationCookie = bookingInfo.ApplicationCookie
+            };
+
+            await _skeddaApiClient.BookAsync(session, bookingInfo.Body, ct);
+
             _logger.LogInformation("Booked court for user {ConfigId}", bookingInfo.UserConfig.Username);
             var ukrainian = new CultureInfo("uk-UA");
             var dayAndDate = bookingInfo.StartTime.ToString("dddd d MMMM", ukrainian);
@@ -168,21 +133,10 @@ public class BookingService {
             var msg = $"🎾 Забронював тенісний корт в Галактиці, {dayAndDate}, {startTime}–{endTime}";
             await _telegram.NotifyAsync(msg);
         }
-        catch (Exception ex) {
+        catch (Exception ex)
+        {
             _logger.LogError(ex, "Failed to book court for user {ConfigId}", bookingInfo.UserConfig.Username);
             throw;
         }
-    }
-
-    private string GetRequestVerificationToken(string loginHtml) {
-        var match = Regex.Match(
-            loginHtml,
-            "<input\\s+name=\\\"__RequestVerificationToken\\\"\\s+type=\\\"hidden\\\"\\s+value=\\\"([^\\\"]+)\\\"",
-            RegexOptions.IgnoreCase
-        );
-        if (!match.Success)
-            throw new InvalidOperationException("__RequestVerificationToken not found in login page HTML.");
-        var requestVerificationToken = match.Groups[1].Value;
-        return requestVerificationToken;
     }
 }

--- a/src/TennisBooking/Services/ISkeddaApiClient.cs
+++ b/src/TennisBooking/Services/ISkeddaApiClient.cs
@@ -1,0 +1,21 @@
+namespace TennisBooking.Services;
+
+public interface ISkeddaApiClient
+{
+    /// <summary>
+    /// Logs into Skedda, navigates to bookings page, and returns session data needed for booking.
+    /// </summary>
+    Task<SkeddaSession> LoginAndGetSessionAsync(string username, string password, CancellationToken ct);
+
+    /// <summary>
+    /// Submits a booking request using the provided session and body.
+    /// </summary>
+    Task BookAsync(SkeddaSession session, object body, CancellationToken ct);
+}
+
+public class SkeddaSession
+{
+    public string RequestVerificationToken { get; set; } = string.Empty;
+    public string CsrfCookie { get; set; } = string.Empty;
+    public string ApplicationCookie { get; set; } = string.Empty;
+}

--- a/src/TennisBooking/Services/SkeddaApiClient.cs
+++ b/src/TennisBooking/Services/SkeddaApiClient.cs
@@ -100,7 +100,7 @@ public class SkeddaApiClient : ISkeddaApiClient
         }
     }
 
-    internal static string GetRequestVerificationToken(string html)
+    public static string GetRequestVerificationToken(string html)
     {
         var match = Regex.Match(
             html,

--- a/src/TennisBooking/Services/SkeddaApiClient.cs
+++ b/src/TennisBooking/Services/SkeddaApiClient.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using TennisBooking.Options;
+
+namespace TennisBooking.Services;
+
+public class SkeddaApiClient : ISkeddaApiClient
+{
+    private const string AccountLoginPath = "/account/login";
+    private const string LoginPath = "/logins";
+    private const string GetBookingsPath = "/booking";
+    private const string BookingPath = "/bookings";
+    private const string CsrfHeaderName = "x-skedda-requestverificationtoken";
+    private const string CookieHeaderName = "Cookie";
+    private const string ApplicationCookieName = "X-Skedda-ApplicationCookie";
+    private const string CsrfCookieName = "X-Skedda-RequestVerificationCookie";
+
+    private readonly SkeddaOptions _opts;
+
+    public SkeddaApiClient(IOptions<SkeddaOptions> opts)
+    {
+        _opts = opts.Value;
+    }
+
+    public async Task<SkeddaSession> LoginAndGetSessionAsync(string username, string password, CancellationToken ct)
+    {
+        var handler = new HttpClientHandler { CookieContainer = new CookieContainer() };
+        var baseUri = new Uri(_opts.ApiBaseUrl);
+        using var client = new HttpClient(handler) { BaseAddress = baseUri };
+
+        var openLoginPage = await client.GetAsync(AccountLoginPath, ct);
+        openLoginPage.EnsureSuccessStatusCode();
+        var loginHtml = await openLoginPage.Content.ReadAsStringAsync(ct);
+        var requestVerificationToken = GetRequestVerificationToken(loginHtml);
+
+        var loginReq = new HttpRequestMessage(HttpMethod.Post, LoginPath);
+        loginReq.Headers.Add(CsrfHeaderName, requestVerificationToken);
+        loginReq.Headers.Add(CookieHeaderName,
+            $"{CsrfCookieName}={handler.CookieContainer.GetCookies(baseUri)[CsrfCookieName]!.Value}");
+
+        loginReq.Content = new StringContent(
+            JsonConvert.SerializeObject(new
+            {
+                login = new
+                {
+                    arbitraryerrors = (object?)null,
+                    username,
+                    password,
+                    rememberMe = false
+                }
+            }),
+            Encoding.UTF8,
+            "application/json"
+        );
+        var loginResp = await client.SendAsync(loginReq, ct);
+        loginResp.EnsureSuccessStatusCode();
+
+        var csrfCookie = handler.CookieContainer.GetCookies(baseUri)[CsrfCookieName]!.Value;
+        var applicationCookie = handler.CookieContainer.GetCookies(baseUri)[ApplicationCookieName]!.Value;
+
+        var getBookingsReq = new HttpRequestMessage(HttpMethod.Get, GetBookingsPath);
+        getBookingsReq.Headers.Add(CsrfHeaderName, requestVerificationToken);
+        getBookingsReq.Headers.Add(CookieHeaderName,
+            $"{CsrfCookieName}={csrfCookie}; " +
+            $"{ApplicationCookieName}={applicationCookie}");
+        var getBookingsResp = await client.SendAsync(getBookingsReq, ct);
+        getBookingsResp.EnsureSuccessStatusCode();
+        var bookingToken = GetRequestVerificationToken(await getBookingsResp.Content.ReadAsStringAsync(ct));
+
+        return new SkeddaSession
+        {
+            RequestVerificationToken = bookingToken,
+            CsrfCookie = csrfCookie,
+            ApplicationCookie = applicationCookie
+        };
+    }
+
+    public async Task BookAsync(SkeddaSession session, object body, CancellationToken ct)
+    {
+        var baseUri = new Uri(_opts.ApiBaseUrl);
+        using var client = new HttpClient { BaseAddress = baseUri };
+
+        var bookReq = new HttpRequestMessage(HttpMethod.Post, BookingPath);
+        bookReq.Content = new StringContent(
+            JsonConvert.SerializeObject(body),
+            Encoding.UTF8,
+            "application/json"
+        );
+        bookReq.Headers.Add(CsrfHeaderName, session.RequestVerificationToken);
+        bookReq.Headers.Add(CookieHeaderName,
+            $"{CsrfCookieName}={session.CsrfCookie}; " +
+            $"{ApplicationCookieName}={session.ApplicationCookie}");
+        var bookResp = await client.SendAsync(bookReq, ct);
+        if (!bookResp.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException($"Response from Skedda {await bookResp.Content.ReadAsStringAsync(ct)}");
+        }
+    }
+
+    internal static string GetRequestVerificationToken(string html)
+    {
+        var match = Regex.Match(
+            html,
+            """<input\s+name="__RequestVerificationToken"\s+type="hidden"\s+value="([^"]+)"\s*/?>""",
+            RegexOptions.IgnoreCase
+        );
+        if (!match.Success)
+            throw new InvalidOperationException("__RequestVerificationToken not found in login page HTML.");
+        return match.Groups[1].Value;
+    }
+}

--- a/src/TennisBooking/Services/TelegramService.cs
+++ b/src/TennisBooking/Services/TelegramService.cs
@@ -22,7 +22,7 @@ public class TelegramService {
         _logger = logger;
     }
 
-    public async Task NotifyAsync(string message) {
+    public virtual async Task NotifyAsync(string message) {
         try {
             var cfg = await GetConfigAsync();
             var url = $"{BaseUrlPrefix}{cfg.BotToken}/sendMessage";

--- a/tests/TennisBooking.Tests/Auth/HangfireBasicAuthFilterTests.cs
+++ b/tests/TennisBooking.Tests/Auth/HangfireBasicAuthFilterTests.cs
@@ -1,0 +1,112 @@
+using System.Text;
+using FluentAssertions;
+using Hangfire.Dashboard;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using TennisBooking.Auth;
+
+namespace TennisBooking.Tests.Auth;
+
+public class HangfireBasicAuthFilterTests
+{
+    private const string ValidUser = "admin";
+    private const string ValidPass = "secret123";
+
+    private readonly HangfireBasicAuthFilter _filter = new(ValidUser, ValidPass);
+
+    private static DashboardContext CreateDashboardContext(string? authorizationHeader = null)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (authorizationHeader != null)
+        {
+            httpContext.Request.Headers["Authorization"] = authorizationHeader;
+        }
+
+        var mock = new Mock<DashboardContext>();
+        mock.Setup(x => x.GetHttpContext()).Returns(httpContext);
+        return mock.Object;
+    }
+
+    private static string EncodeBasicAuth(string user, string pass)
+    {
+        return "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{user}:{pass}"));
+    }
+
+    [Fact]
+    public void Authorize_ValidCredentials_ReturnsTrue()
+    {
+        var context = CreateDashboardContext(EncodeBasicAuth(ValidUser, ValidPass));
+
+        var result = _filter.Authorize(context);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Authorize_NoAuthHeader_ReturnsFalseAndSetsChallenge()
+    {
+        var context = CreateDashboardContext(null);
+
+        var result = _filter.Authorize(context);
+
+        result.Should().BeFalse();
+        var httpContext = context.GetHttpContext();
+        httpContext.Response.StatusCode.Should().Be(401);
+        httpContext.Response.Headers["WWW-Authenticate"].ToString().Should().Contain("Basic");
+    }
+
+    [Fact]
+    public void Authorize_NonBasicScheme_ReturnsFalseAndSetsChallenge()
+    {
+        var context = CreateDashboardContext("Bearer some-token");
+
+        var result = _filter.Authorize(context);
+
+        result.Should().BeFalse();
+        context.GetHttpContext().Response.StatusCode.Should().Be(401);
+    }
+
+    [Fact]
+    public void Authorize_WrongUsername_ReturnsFalse()
+    {
+        var context = CreateDashboardContext(EncodeBasicAuth("wrong", ValidPass));
+
+        var result = _filter.Authorize(context);
+
+        result.Should().BeFalse();
+        context.GetHttpContext().Response.StatusCode.Should().Be(401);
+    }
+
+    [Fact]
+    public void Authorize_WrongPassword_ReturnsFalse()
+    {
+        var context = CreateDashboardContext(EncodeBasicAuth(ValidUser, "wrongpass"));
+
+        var result = _filter.Authorize(context);
+
+        result.Should().BeFalse();
+        context.GetHttpContext().Response.StatusCode.Should().Be(401);
+    }
+
+    [Fact]
+    public void Authorize_EmptyCredentials_ReturnsFalse()
+    {
+        var encoded = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":"));
+        var context = CreateDashboardContext(encoded);
+
+        var result = _filter.Authorize(context);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Authorize_PasswordWithColon_HandledCorrectly()
+    {
+        var filter = new HangfireBasicAuthFilter("user", "pass:with:colons");
+        var context = CreateDashboardContext(EncodeBasicAuth("user", "pass:with:colons"));
+
+        var result = filter.Authorize(context);
+
+        result.Should().BeTrue();
+    }
+}

--- a/tests/TennisBooking.Tests/Auth/HangfireBasicAuthFilterTests.cs
+++ b/tests/TennisBooking.Tests/Auth/HangfireBasicAuthFilterTests.cs
@@ -2,7 +2,6 @@ using System.Text;
 using FluentAssertions;
 using Hangfire.Dashboard;
 using Microsoft.AspNetCore.Http;
-using Moq;
 using TennisBooking.Auth;
 
 namespace TennisBooking.Tests.Auth;
@@ -14,6 +13,19 @@ public class HangfireBasicAuthFilterTests
 
     private readonly HangfireBasicAuthFilter _filter = new(ValidUser, ValidPass);
 
+    private class TestDashboardContext : DashboardContext
+    {
+        private readonly HttpContext _httpContext;
+
+        public TestDashboardContext(HttpContext httpContext)
+            : base(null!, null!, null!)
+        {
+            _httpContext = httpContext;
+        }
+
+        public override HttpContext GetHttpContext() => _httpContext;
+    }
+
     private static DashboardContext CreateDashboardContext(string? authorizationHeader = null)
     {
         var httpContext = new DefaultHttpContext();
@@ -22,9 +34,7 @@ public class HangfireBasicAuthFilterTests
             httpContext.Request.Headers["Authorization"] = authorizationHeader;
         }
 
-        var mock = new Mock<DashboardContext>();
-        mock.Setup(x => x.GetHttpContext()).Returns(httpContext);
-        return mock.Object;
+        return new TestDashboardContext(httpContext);
     }
 
     private static string EncodeBasicAuth(string user, string pass)

--- a/tests/TennisBooking.Tests/Auth/HangfireBasicAuthFilterTests.cs
+++ b/tests/TennisBooking.Tests/Auth/HangfireBasicAuthFilterTests.cs
@@ -1,7 +1,9 @@
 using System.Text;
 using FluentAssertions;
+using Hangfire;
 using Hangfire.Dashboard;
 using Microsoft.AspNetCore.Http;
+using Moq;
 using TennisBooking.Auth;
 
 namespace TennisBooking.Tests.Auth;
@@ -13,19 +15,6 @@ public class HangfireBasicAuthFilterTests
 
     private readonly HangfireBasicAuthFilter _filter = new(ValidUser, ValidPass);
 
-    private class TestDashboardContext : DashboardContext
-    {
-        private readonly HttpContext _httpContext;
-
-        public TestDashboardContext(HttpContext httpContext)
-            : base(null!, null!, null!)
-        {
-            _httpContext = httpContext;
-        }
-
-        public override HttpContext GetHttpContext() => _httpContext;
-    }
-
     private static DashboardContext CreateDashboardContext(string? authorizationHeader = null)
     {
         var httpContext = new DefaultHttpContext();
@@ -34,7 +23,8 @@ public class HangfireBasicAuthFilterTests
             httpContext.Request.Headers["Authorization"] = authorizationHeader;
         }
 
-        return new TestDashboardContext(httpContext);
+        var storage = new Mock<JobStorage>();
+        return new AspNetCoreDashboardContext(storage.Object, new DashboardOptions(), httpContext);
     }
 
     private static string EncodeBasicAuth(string user, string pass)
@@ -46,20 +36,14 @@ public class HangfireBasicAuthFilterTests
     public void Authorize_ValidCredentials_ReturnsTrue()
     {
         var context = CreateDashboardContext(EncodeBasicAuth(ValidUser, ValidPass));
-
-        var result = _filter.Authorize(context);
-
-        result.Should().BeTrue();
+        _filter.Authorize(context).Should().BeTrue();
     }
 
     [Fact]
     public void Authorize_NoAuthHeader_ReturnsFalseAndSetsChallenge()
     {
         var context = CreateDashboardContext(null);
-
-        var result = _filter.Authorize(context);
-
-        result.Should().BeFalse();
+        _filter.Authorize(context).Should().BeFalse();
         var httpContext = context.GetHttpContext();
         httpContext.Response.StatusCode.Should().Be(401);
         httpContext.Response.Headers["WWW-Authenticate"].ToString().Should().Contain("Basic");
@@ -69,10 +53,7 @@ public class HangfireBasicAuthFilterTests
     public void Authorize_NonBasicScheme_ReturnsFalseAndSetsChallenge()
     {
         var context = CreateDashboardContext("Bearer some-token");
-
-        var result = _filter.Authorize(context);
-
-        result.Should().BeFalse();
+        _filter.Authorize(context).Should().BeFalse();
         context.GetHttpContext().Response.StatusCode.Should().Be(401);
     }
 
@@ -80,10 +61,7 @@ public class HangfireBasicAuthFilterTests
     public void Authorize_WrongUsername_ReturnsFalse()
     {
         var context = CreateDashboardContext(EncodeBasicAuth("wrong", ValidPass));
-
-        var result = _filter.Authorize(context);
-
-        result.Should().BeFalse();
+        _filter.Authorize(context).Should().BeFalse();
         context.GetHttpContext().Response.StatusCode.Should().Be(401);
     }
 
@@ -91,10 +69,7 @@ public class HangfireBasicAuthFilterTests
     public void Authorize_WrongPassword_ReturnsFalse()
     {
         var context = CreateDashboardContext(EncodeBasicAuth(ValidUser, "wrongpass"));
-
-        var result = _filter.Authorize(context);
-
-        result.Should().BeFalse();
+        _filter.Authorize(context).Should().BeFalse();
         context.GetHttpContext().Response.StatusCode.Should().Be(401);
     }
 
@@ -103,10 +78,7 @@ public class HangfireBasicAuthFilterTests
     {
         var encoded = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":"));
         var context = CreateDashboardContext(encoded);
-
-        var result = _filter.Authorize(context);
-
-        result.Should().BeFalse();
+        _filter.Authorize(context).Should().BeFalse();
     }
 
     [Fact]
@@ -114,9 +86,6 @@ public class HangfireBasicAuthFilterTests
     {
         var filter = new HangfireBasicAuthFilter("user", "pass:with:colons");
         var context = CreateDashboardContext(EncodeBasicAuth("user", "pass:with:colons"));
-
-        var result = filter.Authorize(context);
-
-        result.Should().BeTrue();
+        filter.Authorize(context).Should().BeTrue();
     }
 }

--- a/tests/TennisBooking.Tests/Auth/HangfireBasicAuthFilterTests.cs
+++ b/tests/TennisBooking.Tests/Auth/HangfireBasicAuthFilterTests.cs
@@ -23,6 +23,7 @@ public class HangfireBasicAuthFilterTests
             httpContext.Request.Headers["Authorization"] = authorizationHeader;
         }
 
+        httpContext.RequestServices = new Mock<IServiceProvider>().Object;
         var storage = new Mock<JobStorage>();
         return new AspNetCoreDashboardContext(storage.Object, new DashboardOptions(), httpContext);
     }

--- a/tests/TennisBooking.Tests/DAL/ApplicationDbContextTests.cs
+++ b/tests/TennisBooking.Tests/DAL/ApplicationDbContextTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using TennisBooking.DAL.Models;
+using TennisBooking.Tests.Helpers;
+
+namespace TennisBooking.Tests.DAL;
+
+public class ApplicationDbContextTests
+{
+    [Fact]
+    public async Task UserConfigs_CanAddAndRetrieve()
+    {
+        var db = TestDbContextFactory.Create();
+
+        db.UserConfigs.Add(new UserConfig
+        {
+            Username = "test@example.com",
+            Password = "pass",
+            ResourceId = "r1",
+            Venue = "v1",
+            VenueUser = "vu1",
+            DayOfWeek = DayOfWeek.Friday,
+            Hour = 10
+        });
+        await db.SaveChangesAsync();
+
+        var configs = db.UserConfigs.ToList();
+        configs.Should().HaveCount(1);
+        configs[0].Username.Should().Be("test@example.com");
+        configs[0].DayOfWeek.Should().Be(DayOfWeek.Friday);
+    }
+
+    [Fact]
+    public async Task TelegramConfigs_CanAddAndRetrieve()
+    {
+        var db = TestDbContextFactory.Create();
+
+        db.TelegramConfigs.Add(new TelegramConfig
+        {
+            BotToken = "123:ABC",
+            ChatId = 555
+        });
+        await db.SaveChangesAsync();
+
+        var configs = db.TelegramConfigs.ToList();
+        configs.Should().HaveCount(1);
+        configs[0].BotToken.Should().Be("123:ABC");
+        configs[0].ChatId.Should().Be(555);
+    }
+
+    [Fact]
+    public async Task MultipleUserConfigs_CanCoexist()
+    {
+        var db = TestDbContextFactory.Create();
+
+        db.UserConfigs.AddRange(
+            new UserConfig { Username = "u1", Password = "p1", ResourceId = "r1", Venue = "v1", VenueUser = "vu1", Hour = 10 },
+            new UserConfig { Username = "u2", Password = "p2", ResourceId = "r2", Venue = "v2", VenueUser = "vu2", Hour = 14 }
+        );
+        await db.SaveChangesAsync();
+
+        db.UserConfigs.Count().Should().Be(2);
+    }
+}

--- a/tests/TennisBooking.Tests/GlobalUsings.cs
+++ b/tests/TennisBooking.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using System.Net;

--- a/tests/TennisBooking.Tests/HealthChecks/PreparationHealthCheckTests.cs
+++ b/tests/TennisBooking.Tests/HealthChecks/PreparationHealthCheckTests.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TennisBooking.DAL.Models;
+using TennisBooking.HealthChecks;
+using TennisBooking.Services;
+using TennisBooking.Tests.Helpers;
+
+namespace TennisBooking.Tests.HealthChecks;
+
+public class PreparationHealthCheckTests
+{
+    [Fact]
+    public async Task CheckHealthAsync_PreparationSucceeds_ReturnsHealthy()
+    {
+        var db = TestDbContextFactory.Create();
+        db.UserConfigs.Add(new UserConfig
+        {
+            Id = 1,
+            Username = "test@example.com",
+            Password = "pass",
+            ResourceId = "r1",
+            Venue = "v1",
+            VenueUser = "vu1",
+            DayOfWeek = DayOfWeek.Monday,
+            Hour = 18
+        });
+        await db.SaveChangesAsync();
+
+        var bookingServiceMock = new Mock<BookingService>(
+            new Mock<ILogger<BookingService>>().Object,
+            Microsoft.Extensions.Options.Options.Create(new TennisBooking.Options.SkeddaOptions { ApiBaseUrl = "https://fake.example.com" }),
+            CreateMockTelegramService(),
+            new Mock<Hangfire.IBackgroundJobClient>().Object,
+            new Mock<ISkeddaApiClient>().Object)
+        { CallBase = false };
+
+        bookingServiceMock
+            .Setup(x => x.Preparation(It.IsAny<UserConfig>(), false, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var logger = new Mock<ILogger<PreparationHealthCheck>>();
+        var healthCheck = new PreparationHealthCheck(bookingServiceMock.Object, db, logger.Object);
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_PreparationThrows_ReturnsUnhealthy()
+    {
+        var db = TestDbContextFactory.Create();
+        db.UserConfigs.Add(new UserConfig
+        {
+            Id = 1,
+            Username = "test@example.com",
+            Password = "pass",
+            ResourceId = "r1",
+            Venue = "v1",
+            VenueUser = "vu1",
+            DayOfWeek = DayOfWeek.Monday,
+            Hour = 18
+        });
+        await db.SaveChangesAsync();
+
+        var bookingServiceMock = new Mock<BookingService>(
+            new Mock<ILogger<BookingService>>().Object,
+            Microsoft.Extensions.Options.Options.Create(new TennisBooking.Options.SkeddaOptions { ApiBaseUrl = "https://fake.example.com" }),
+            CreateMockTelegramService(),
+            new Mock<Hangfire.IBackgroundJobClient>().Object,
+            new Mock<ISkeddaApiClient>().Object)
+        { CallBase = false };
+
+        bookingServiceMock
+            .Setup(x => x.Preparation(It.IsAny<UserConfig>(), false, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("API down"));
+
+        var logger = new Mock<ILogger<PreparationHealthCheck>>();
+        var healthCheck = new PreparationHealthCheck(bookingServiceMock.Object, db, logger.Object);
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_NoUserConfigs_CallsPreparationWithNull()
+    {
+        var db = TestDbContextFactory.Create();
+        // No UserConfigs in DB
+
+        var bookingServiceMock = new Mock<BookingService>(
+            new Mock<ILogger<BookingService>>().Object,
+            Microsoft.Extensions.Options.Options.Create(new TennisBooking.Options.SkeddaOptions { ApiBaseUrl = "https://fake.example.com" }),
+            CreateMockTelegramService(),
+            new Mock<Hangfire.IBackgroundJobClient>().Object,
+            new Mock<ISkeddaApiClient>().Object)
+        { CallBase = false };
+
+        bookingServiceMock
+            .Setup(x => x.Preparation(null!, false, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var logger = new Mock<ILogger<PreparationHealthCheck>>();
+        var healthCheck = new PreparationHealthCheck(bookingServiceMock.Object, db, logger.Object);
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+
+        bookingServiceMock.Verify(
+            x => x.Preparation(null!, false, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static TelegramService CreateMockTelegramService()
+    {
+        var httpClient = new HttpClient();
+        var db = TestDbContextFactory.Create();
+        var logger = new Mock<ILogger<TelegramService>>();
+        var mock = new Mock<TelegramService>(httpClient, db, logger.Object) { CallBase = false };
+        return mock.Object;
+    }
+}

--- a/tests/TennisBooking.Tests/Helpers/MockCookieHttpMessageHandler.cs
+++ b/tests/TennisBooking.Tests/Helpers/MockCookieHttpMessageHandler.cs
@@ -1,0 +1,46 @@
+using System.Net;
+
+namespace TennisBooking.Tests.Helpers;
+
+/// <summary>
+/// A mock handler that works with HttpClientHandler's CookieContainer
+/// by simulating Set-Cookie headers from Skedda API responses.
+/// </summary>
+public class MockCookieHttpMessageHandler : DelegatingHandler
+{
+    private readonly Queue<(HttpStatusCode Status, string Content, Dictionary<string, string>? Cookies)> _responses = new();
+    private readonly List<HttpRequestMessage> _requests = new();
+
+    public IReadOnlyList<HttpRequestMessage> Requests => _requests;
+
+    public void EnqueueResponse(HttpStatusCode statusCode, string content, Dictionary<string, string>? cookies = null)
+    {
+        _responses.Enqueue((statusCode, content, cookies));
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        _requests.Add(request);
+
+        if (_responses.Count == 0)
+            throw new InvalidOperationException($"No more mock responses queued. Request: {request.Method} {request.RequestUri}");
+
+        var (status, content, cookies) = _responses.Dequeue();
+
+        var response = new HttpResponseMessage(status)
+        {
+            Content = new StringContent(content, System.Text.Encoding.UTF8, "text/html"),
+            RequestMessage = request
+        };
+
+        if (cookies != null)
+        {
+            foreach (var cookie in cookies)
+            {
+                response.Headers.TryAddWithoutValidation("Set-Cookie", $"{cookie.Key}={cookie.Value}; Path=/");
+            }
+        }
+
+        return Task.FromResult(response);
+    }
+}

--- a/tests/TennisBooking.Tests/Helpers/MockHttpMessageHandler.cs
+++ b/tests/TennisBooking.Tests/Helpers/MockHttpMessageHandler.cs
@@ -1,0 +1,32 @@
+namespace TennisBooking.Tests.Helpers;
+
+public class MockHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Queue<HttpResponseMessage> _responses = new();
+    private readonly List<HttpRequestMessage> _requests = new();
+
+    public IReadOnlyList<HttpRequestMessage> Requests => _requests;
+
+    public void EnqueueResponse(HttpResponseMessage response)
+    {
+        _responses.Enqueue(response);
+    }
+
+    public void EnqueueResponse(HttpStatusCode statusCode, string content = "", string mediaType = "application/json")
+    {
+        _responses.Enqueue(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(content, System.Text.Encoding.UTF8, mediaType)
+        });
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        _requests.Add(request);
+
+        if (_responses.Count == 0)
+            throw new InvalidOperationException($"No more mock responses queued. Request: {request.Method} {request.RequestUri}");
+
+        return Task.FromResult(_responses.Dequeue());
+    }
+}

--- a/tests/TennisBooking.Tests/Helpers/TestDbContextFactory.cs
+++ b/tests/TennisBooking.Tests/Helpers/TestDbContextFactory.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using TennisBooking.DAL;
+
+namespace TennisBooking.Tests.Helpers;
+
+public static class TestDbContextFactory
+{
+    public static ApplicationDbContext Create(string? dbName = null)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(dbName ?? Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+}

--- a/tests/TennisBooking.Tests/Models/ModelsTests.cs
+++ b/tests/TennisBooking.Tests/Models/ModelsTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using TennisBooking.DAL.Models;
+using TennisBooking.Models;
+using TennisBooking.Options;
+using TennisBooking.Services;
+
+namespace TennisBooking.Tests.Models;
+
+public class ModelsTests
+{
+    [Fact]
+    public void BookingInfo_Properties_SetAndGetCorrectly()
+    {
+        var userConfig = new UserConfig { Id = 1, Username = "test" };
+        var body = new { key = "value" };
+        var startTime = DateTimeOffset.UtcNow;
+
+        var bookingInfo = new BookingInfo
+        {
+            UserConfig = userConfig,
+            Body = body,
+            RequestVerificationToken = "token",
+            CsrfCookie = "csrf",
+            ApplicationCookie = "app",
+            StartTime = startTime
+        };
+
+        bookingInfo.UserConfig.Should().Be(userConfig);
+        bookingInfo.Body.Should().Be(body);
+        bookingInfo.RequestVerificationToken.Should().Be("token");
+        bookingInfo.CsrfCookie.Should().Be("csrf");
+        bookingInfo.ApplicationCookie.Should().Be("app");
+        bookingInfo.StartTime.Should().Be(startTime);
+    }
+
+    [Fact]
+    public void UserConfig_Properties_SetAndGetCorrectly()
+    {
+        var config = new UserConfig
+        {
+            Id = 42,
+            Username = "user@test.com",
+            Password = "pass123",
+            ResourceId = "court-1",
+            Venue = "venue-1",
+            VenueUser = "venue-user-1",
+            DayOfWeek = DayOfWeek.Wednesday,
+            Hour = 14
+        };
+
+        config.Id.Should().Be(42);
+        config.Username.Should().Be("user@test.com");
+        config.Password.Should().Be("pass123");
+        config.ResourceId.Should().Be("court-1");
+        config.Venue.Should().Be("venue-1");
+        config.VenueUser.Should().Be("venue-user-1");
+        config.DayOfWeek.Should().Be(DayOfWeek.Wednesday);
+        config.Hour.Should().Be(14);
+    }
+
+    [Fact]
+    public void TelegramConfig_Properties_SetAndGetCorrectly()
+    {
+        var config = new TelegramConfig
+        {
+            Id = 1,
+            BotToken = "123:ABC",
+            ChatId = 99887766
+        };
+
+        config.Id.Should().Be(1);
+        config.BotToken.Should().Be("123:ABC");
+        config.ChatId.Should().Be(99887766);
+    }
+
+    [Fact]
+    public void SkeddaOptions_Properties_SetAndGetCorrectly()
+    {
+        var options = new SkeddaOptions
+        {
+            ApiBaseUrl = "https://skedda.example.com"
+        };
+
+        options.ApiBaseUrl.Should().Be("https://skedda.example.com");
+    }
+
+    [Fact]
+    public void SkeddaSession_Properties_SetAndGetCorrectly()
+    {
+        var session = new SkeddaSession
+        {
+            RequestVerificationToken = "token-123",
+            CsrfCookie = "csrf-456",
+            ApplicationCookie = "app-789"
+        };
+
+        session.RequestVerificationToken.Should().Be("token-123");
+        session.CsrfCookie.Should().Be("csrf-456");
+        session.ApplicationCookie.Should().Be("app-789");
+    }
+
+    [Fact]
+    public void SkeddaSession_DefaultValues_AreEmptyStrings()
+    {
+        var session = new SkeddaSession();
+
+        session.RequestVerificationToken.Should().BeEmpty();
+        session.CsrfCookie.Should().BeEmpty();
+        session.ApplicationCookie.Should().BeEmpty();
+    }
+}

--- a/tests/TennisBooking.Tests/Services/BookingServiceTests.cs
+++ b/tests/TennisBooking.Tests/Services/BookingServiceTests.cs
@@ -37,7 +37,7 @@ public class BookingServiceTests
 
     public BookingServiceTests()
     {
-        _options = Options.Create(new SkeddaOptions { ApiBaseUrl = "https://fake-skedda.example.com" });
+        _options = Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = "https://fake-skedda.example.com" });
 
         var httpClient = new HttpClient();
         var db = TestDbContextFactory.Create();

--- a/tests/TennisBooking.Tests/Services/BookingServiceTests.cs
+++ b/tests/TennisBooking.Tests/Services/BookingServiceTests.cs
@@ -1,0 +1,290 @@
+using System.Globalization;
+using System.Net;
+using FluentAssertions;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using TennisBooking.DAL.Models;
+using TennisBooking.Models;
+using TennisBooking.Options;
+using TennisBooking.Services;
+using TennisBooking.Tests.Helpers;
+
+namespace TennisBooking.Tests.Services;
+
+public class BookingServiceTests
+{
+    private static readonly UserConfig TestUserConfig = new()
+    {
+        Id = 1,
+        Username = "testuser@example.com",
+        Password = "testpassword",
+        ResourceId = "court-1",
+        Venue = "test-venue",
+        VenueUser = "test-venue-user",
+        DayOfWeek = DayOfWeek.Monday,
+        Hour = 18
+    };
+
+    private readonly Mock<ILogger<BookingService>> _loggerMock = new();
+    private readonly Mock<IBackgroundJobClient> _backgroundJobClientMock = new();
+    private readonly Mock<TelegramService> _telegramMock;
+    private readonly Mock<ISkeddaApiClient> _skeddaApiClientMock = new();
+    private readonly IOptions<SkeddaOptions> _options;
+
+    public BookingServiceTests()
+    {
+        _options = Options.Create(new SkeddaOptions { ApiBaseUrl = "https://fake-skedda.example.com" });
+
+        var httpClient = new HttpClient();
+        var db = TestDbContextFactory.Create();
+        var logger = new Mock<ILogger<TelegramService>>();
+        _telegramMock = new Mock<TelegramService>(httpClient, db, logger.Object) { CallBase = false };
+        _telegramMock.Setup(x => x.NotifyAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+    }
+
+    private BookingService CreateService()
+    {
+        return new BookingService(
+            _loggerMock.Object,
+            _options,
+            _telegramMock.Object,
+            _backgroundJobClientMock.Object,
+            _skeddaApiClientMock.Object);
+    }
+
+    // ── Preparation ──
+
+    [Fact]
+    public async Task Preparation_NullUserConfig_LogsErrorAndReturns()
+    {
+        var service = CreateService();
+
+        await service.Preparation(null!, false, CancellationToken.None);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("UserConfig is null")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        _skeddaApiClientMock.Verify(
+            x => x.LoginAndGetSessionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Preparation_ValidConfig_NoSchedule_CallsLoginButDoesNotSchedule()
+    {
+        _skeddaApiClientMock
+            .Setup(x => x.LoginAndGetSessionAsync(TestUserConfig.Username, TestUserConfig.Password, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SkeddaSession
+            {
+                RequestVerificationToken = "token-123",
+                CsrfCookie = "csrf-cookie",
+                ApplicationCookie = "app-cookie"
+            });
+
+        var service = CreateService();
+
+        await service.Preparation(TestUserConfig, false, CancellationToken.None);
+
+        _skeddaApiClientMock.Verify(
+            x => x.LoginAndGetSessionAsync(TestUserConfig.Username, TestUserConfig.Password, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _backgroundJobClientMock.Verify(
+            x => x.Create(It.IsAny<Job>(), It.IsAny<IState>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Preparation_ValidConfig_WithSchedule_SchedulesBookingJob()
+    {
+        _skeddaApiClientMock
+            .Setup(x => x.LoginAndGetSessionAsync(TestUserConfig.Username, TestUserConfig.Password, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SkeddaSession
+            {
+                RequestVerificationToken = "token-123",
+                CsrfCookie = "csrf-cookie",
+                ApplicationCookie = "app-cookie"
+            });
+
+        var service = CreateService();
+
+        await service.Preparation(TestUserConfig, true, CancellationToken.None);
+
+        _backgroundJobClientMock.Verify(
+            x => x.Create(It.IsAny<Job>(), It.IsAny<ScheduledState>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Preparation_ApiThrows_LogsErrorAndRethrows()
+    {
+        _skeddaApiClientMock
+            .Setup(x => x.LoginAndGetSessionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Connection refused"));
+
+        var service = CreateService();
+
+        var act = () => service.Preparation(TestUserConfig, false, CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>().WithMessage("Connection refused");
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Failed to book court")),
+                It.IsAny<HttpRequestException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    // ── Booking ──
+
+    [Fact]
+    public async Task Booking_NullBookingInfo_LogsErrorAndReturns()
+    {
+        var service = CreateService();
+
+        await service.Booking(null!, CancellationToken.None);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("BookingInfo is null")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        _skeddaApiClientMock.Verify(
+            x => x.BookAsync(It.IsAny<SkeddaSession>(), It.IsAny<object>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Booking_ValidInfo_Success_SendsTelegramNotification()
+    {
+        _skeddaApiClientMock
+            .Setup(x => x.BookAsync(It.IsAny<SkeddaSession>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var tz = TimeZoneInfo.FindSystemTimeZoneById("Europe/Kyiv");
+        var startTime = new DateTimeOffset(2026, 3, 10, 18, 0, 0, tz.GetUtcOffset(new DateTime(2026, 3, 10)));
+
+        var bookingInfo = new BookingInfo
+        {
+            UserConfig = TestUserConfig,
+            Body = new { booking = new { title = "test" } },
+            RequestVerificationToken = "test-token",
+            CsrfCookie = "csrf-cookie-value",
+            ApplicationCookie = "app-cookie-value",
+            StartTime = startTime
+        };
+
+        var service = CreateService();
+
+        await service.Booking(bookingInfo, CancellationToken.None);
+
+        _skeddaApiClientMock.Verify(
+            x => x.BookAsync(
+                It.Is<SkeddaSession>(s =>
+                    s.RequestVerificationToken == "test-token" &&
+                    s.CsrfCookie == "csrf-cookie-value" &&
+                    s.ApplicationCookie == "app-cookie-value"),
+                bookingInfo.Body,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _telegramMock.Verify(x => x.NotifyAsync(It.Is<string>(msg => msg.Contains("🎾") && msg.Contains("18:00"))), Times.Once);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Booked court")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Booking_ApiThrows_LogsErrorAndRethrows()
+    {
+        _skeddaApiClientMock
+            .Setup(x => x.BookAsync(It.IsAny<SkeddaSession>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Response from Skedda: 403 Forbidden"));
+
+        var tz = TimeZoneInfo.FindSystemTimeZoneById("Europe/Kyiv");
+        var startTime = new DateTimeOffset(2026, 3, 10, 18, 0, 0, tz.GetUtcOffset(new DateTime(2026, 3, 10)));
+
+        var bookingInfo = new BookingInfo
+        {
+            UserConfig = TestUserConfig,
+            Body = new { booking = new { title = "test" } },
+            RequestVerificationToken = "test-token",
+            CsrfCookie = "csrf",
+            ApplicationCookie = "app",
+            StartTime = startTime
+        };
+
+        var service = CreateService();
+
+        var act = () => service.Booking(bookingInfo, CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Failed to book court")),
+                It.IsAny<HttpRequestException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        _telegramMock.Verify(x => x.NotifyAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Booking_TelegramFormatsMessageCorrectly()
+    {
+        _skeddaApiClientMock
+            .Setup(x => x.BookAsync(It.IsAny<SkeddaSession>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var tz = TimeZoneInfo.FindSystemTimeZoneById("Europe/Kyiv");
+        var startTime = new DateTimeOffset(2026, 3, 10, 18, 0, 0, tz.GetUtcOffset(new DateTime(2026, 3, 10)));
+
+        var bookingInfo = new BookingInfo
+        {
+            UserConfig = TestUserConfig,
+            Body = new { },
+            RequestVerificationToken = "t",
+            CsrfCookie = "c",
+            ApplicationCookie = "a",
+            StartTime = startTime
+        };
+
+        var service = CreateService();
+        await service.Booking(bookingInfo, CancellationToken.None);
+
+        var expectedStart = startTime.ToString("HH:mm", new CultureInfo("uk-UA"));
+        var expectedEnd = startTime.AddHours(1).ToString("HH:mm", new CultureInfo("uk-UA"));
+
+        _telegramMock.Verify(x => x.NotifyAsync(
+            It.Is<string>(msg =>
+                msg.Contains("🎾 Забронював тенісний корт в Галактиці") &&
+                msg.Contains($"{expectedStart}–{expectedEnd}"))),
+            Times.Once);
+    }
+}

--- a/tests/TennisBooking.Tests/Services/SkeddaApiClientTests.cs
+++ b/tests/TennisBooking.Tests/Services/SkeddaApiClientTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using TennisBooking.Services;
+
+namespace TennisBooking.Tests.Services;
+
+public class SkeddaApiClientTests
+{
+    [Fact]
+    public void GetRequestVerificationToken_ValidHtml_ReturnsToken()
+    {
+        var html = """
+            <html>
+            <body>
+                <input name="__RequestVerificationToken" type="hidden" value="my-csrf-token-abc123" />
+            </body>
+            </html>
+            """;
+
+        var token = SkeddaApiClient.GetRequestVerificationToken(html);
+
+        token.Should().Be("my-csrf-token-abc123");
+    }
+
+    [Fact]
+    public void GetRequestVerificationToken_SelfClosingTag_ReturnsToken()
+    {
+        var html = """<input name="__RequestVerificationToken" type="hidden" value="token-456"/>""";
+
+        var token = SkeddaApiClient.GetRequestVerificationToken(html);
+
+        token.Should().Be("token-456");
+    }
+
+    [Fact]
+    public void GetRequestVerificationToken_NoToken_ThrowsInvalidOperationException()
+    {
+        var html = "<html><body>No token here</body></html>";
+
+        var act = () => SkeddaApiClient.GetRequestVerificationToken(html);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*__RequestVerificationToken*not found*");
+    }
+
+    [Fact]
+    public void GetRequestVerificationToken_EmptyHtml_ThrowsInvalidOperationException()
+    {
+        var act = () => SkeddaApiClient.GetRequestVerificationToken(string.Empty);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void GetRequestVerificationToken_CaseInsensitive_ReturnsToken()
+    {
+        var html = """<INPUT NAME="__RequestVerificationToken" TYPE="hidden" VALUE="case-insensitive-token" />""";
+
+        var token = SkeddaApiClient.GetRequestVerificationToken(html);
+
+        token.Should().Be("case-insensitive-token");
+    }
+}

--- a/tests/TennisBooking.Tests/Services/TelegramServiceTests.cs
+++ b/tests/TennisBooking.Tests/Services/TelegramServiceTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TennisBooking.DAL.Models;
+using TennisBooking.Services;
+using TennisBooking.Tests.Helpers;
+
+namespace TennisBooking.Tests.Services;
+
+public class TelegramServiceTests
+{
+    [Fact]
+    public async Task NotifyAsync_ValidConfig_SendsMessageToTelegramApi()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.EnqueueResponse(HttpStatusCode.OK, """{"ok": true}""");
+        var httpClient = new HttpClient(handler);
+
+        var db = TestDbContextFactory.Create();
+        db.TelegramConfigs.Add(new TelegramConfig
+        {
+            Id = 1,
+            BotToken = "123456:ABC-DEF",
+            ChatId = 987654321
+        });
+        await db.SaveChangesAsync();
+
+        var logger = new Mock<ILogger<TelegramService>>();
+        var service = new TelegramService(httpClient, db, logger.Object);
+
+        await service.NotifyAsync("Test message");
+
+        handler.Requests.Should().HaveCount(1);
+        var request = handler.Requests[0];
+        request.Method.Should().Be(HttpMethod.Post);
+        request.RequestUri!.ToString().Should().Contain("123456:ABC-DEF/sendMessage");
+
+        var body = await request.Content!.ReadAsStringAsync();
+        body.Should().Contain("987654321");
+        body.Should().Contain("Test message");
+        body.Should().Contain("MarkdownV2");
+    }
+
+    [Fact]
+    public async Task NotifyAsync_NoConfig_LogsErrorAndDoesNotThrow()
+    {
+        var handler = new MockHttpMessageHandler();
+        var httpClient = new HttpClient(handler);
+
+        var db = TestDbContextFactory.Create();
+        // No TelegramConfig in DB
+
+        var logger = new Mock<ILogger<TelegramService>>();
+        var service = new TelegramService(httpClient, db, logger.Object);
+
+        // Should not throw
+        await service.NotifyAsync("Test message");
+
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Failed to send Telegram notification")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task NotifyAsync_ApiReturnsError_LogsErrorAndDoesNotThrow()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.EnqueueResponse(HttpStatusCode.BadRequest, """{"ok": false}""");
+        var httpClient = new HttpClient(handler);
+
+        var db = TestDbContextFactory.Create();
+        db.TelegramConfigs.Add(new TelegramConfig
+        {
+            Id = 1,
+            BotToken = "token",
+            ChatId = 123
+        });
+        await db.SaveChangesAsync();
+
+        var logger = new Mock<ILogger<TelegramService>>();
+        var service = new TelegramService(httpClient, db, logger.Object);
+
+        await service.NotifyAsync("Fail message");
+
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Failed to send Telegram notification")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/TennisBooking.Tests/TennisBooking.Tests.csproj
+++ b/tests/TennisBooking.Tests/TennisBooking.Tests.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="FluentAssertions" Version="7.2.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     </ItemGroup>

--- a/tests/TennisBooking.Tests/TennisBooking.Tests.csproj
+++ b/tests/TennisBooking.Tests/TennisBooking.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="FluentAssertions" Version="7.2.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\TennisBooking\TennisBooking.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Refactoring
- Extracted ISkeddaApiClient interface for testable HTTP calls to Skedda
- Created SkeddaApiClient implementation (logic moved from BookingService)
- BookingService now uses ISkeddaApiClient via DI
- Key methods made virtual for Moq proxy support

## Tests (xUnit + Moq + FluentAssertions)
- BookingService: null checks, preparation flow, job scheduling, booking + Telegram notification, error handling
- TelegramService: successful send, missing config, API error
- SkeddaApiClient: CSRF token parsing (valid/invalid/case-insensitive HTML)
- HangfireBasicAuthFilter: valid/invalid credentials, missing header, wrong scheme, edge cases
- PreparationHealthCheck: healthy/unhealthy/no configs
- Models: property tests for all models
- ApplicationDbContext: CRUD with InMemory provider

## CI
- GitHub Actions: build + test + coverage report

No real API calls to Skedda.