### PR TITLE
Hybrid booking trigger: precise in-process timer + Hangfire fallback

### DIFF
--- a/src/TennisBooking/Program.cs
+++ b/src/TennisBooking/Program.cs
@@ -6,9 +6,11 @@ using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using System.Collections.Concurrent;
 using TennisBooking.Auth;
 using TennisBooking.DAL;
 using TennisBooking.HealthChecks;
+using TennisBooking.Models;
 using TennisBooking.Options;
 using TennisBooking.Services;
 
@@ -42,6 +44,9 @@ builder.Services.AddHangfireServer(options =>
 {
     options.SchedulePollingInterval = TimeSpan.FromMilliseconds(10);
 });
+builder.Services.AddSingleton<PreciseBookingScheduler>();
+builder.Services.AddSingleton<IPreciseBookingScheduler>(sp => sp.GetRequiredService<PreciseBookingScheduler>());
+builder.Services.AddHostedService(sp => sp.GetRequiredService<PreciseBookingScheduler>());
 builder.Services.AddScoped<BookingService>();
 builder.Services.AddScoped<TelegramService>();
 builder.Services.AddControllers();
@@ -131,3 +136,98 @@ using (var scope = app.Services.CreateScope()) {
 }
 
 app.Run();
+
+namespace TennisBooking.Services
+{
+public interface IPreciseBookingScheduler
+{
+    void ScheduleBooking(BookingInfo bookingInfo);
+}
+
+public sealed class PreciseBookingScheduler : IPreciseBookingScheduler, IHostedService, IDisposable
+{
+    private static readonly TimeSpan WarmupBeforeTarget = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan PrecisionStep = TimeSpan.FromMilliseconds(20);
+
+    private readonly ConcurrentDictionary<string, byte> _scheduled = new();
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<PreciseBookingScheduler> _logger;
+    private readonly CancellationTokenSource _stoppingCts = new();
+
+    public PreciseBookingScheduler(IServiceScopeFactory scopeFactory, ILogger<PreciseBookingScheduler> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _stoppingCts.Cancel();
+        return Task.CompletedTask;
+    }
+
+    public void ScheduleBooking(BookingInfo bookingInfo)
+    {
+        if (bookingInfo == null)
+            return;
+
+        var key = BuildKey(bookingInfo);
+        if (!_scheduled.TryAdd(key, 0))
+        {
+            _logger.LogInformation("Precise booking timer already scheduled for {Key}", key);
+            return;
+        }
+
+        _ = Task.Run(() => RunPreciseTimerAsync(bookingInfo, key, _stoppingCts.Token));
+    }
+
+    private async Task RunPreciseTimerAsync(BookingInfo bookingInfo, string key, CancellationToken token)
+    {
+        try
+        {
+            var targetTime = bookingInfo.StartTime.AddDays(-14).ToUniversalTime();
+            var warmupTime = targetTime - WarmupBeforeTarget;
+            var now = DateTimeOffset.UtcNow;
+
+            if (warmupTime > now)
+                await Task.Delay(warmupTime - now, token);
+
+            while (DateTimeOffset.UtcNow < targetTime)
+            {
+                var remaining = targetTime - DateTimeOffset.UtcNow;
+                var delay = remaining > PrecisionStep ? PrecisionStep : remaining;
+                if (delay > TimeSpan.Zero)
+                    await Task.Delay(delay, token);
+            }
+
+            using var scope = _scopeFactory.CreateScope();
+            var bookingService = scope.ServiceProvider.GetRequiredService<BookingService>();
+            await bookingService.Booking(bookingInfo, token);
+            _logger.LogInformation("Precise timer triggered booking for {Username} at {Target}", bookingInfo.UserConfig.Username, targetTime);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Precise booking timer cancelled for {Key}", key);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Precise booking timer failed for {Key}", key);
+        }
+        finally
+        {
+            _scheduled.TryRemove(key, out _);
+        }
+    }
+
+    private static string BuildKey(BookingInfo bookingInfo)
+        => $"{bookingInfo.UserConfig.Username}:{bookingInfo.StartTime.ToUnixTimeMilliseconds()}";
+
+    public void Dispose()
+    {
+        _stoppingCts.Cancel();
+        _stoppingCts.Dispose();
+    }
+}
+}

--- a/src/TennisBooking/Services/BookingService.cs
+++ b/src/TennisBooking/Services/BookingService.cs
@@ -25,16 +25,19 @@ public class BookingService {
     private readonly SkeddaOptions _opts;
     private readonly IBackgroundJobClient _backgroundJobClient;
     private readonly TelegramService _telegram;
+    private readonly IPreciseBookingScheduler _preciseBookingScheduler;
 
     public BookingService(
         ILogger<BookingService> logger,
         IOptions<SkeddaOptions> opts,
         TelegramService telegram,
-        IBackgroundJobClient backgroundJobClient) {
+        IBackgroundJobClient backgroundJobClient,
+        IPreciseBookingScheduler preciseBookingScheduler) {
         _logger = logger;
         _opts = opts.Value;
         _backgroundJobClient = backgroundJobClient;
         _telegram = telegram;
+        _preciseBookingScheduler = preciseBookingScheduler;
     }
 
     public async Task Preparation(UserConfig userConfig, bool scheduleBookingJob, CancellationToken ct) {
@@ -127,7 +130,15 @@ public class BookingService {
                 StartTime = startTime,
             };
             if (scheduleBookingJob) {
-                _backgroundJobClient.Schedule<BookingService>(x => x.Booking(bookingInfo, ct), startTime.AddDays(-14));
+                var targetTime = startTime.AddDays(-14);
+                _preciseBookingScheduler.ScheduleBooking(bookingInfo);
+
+                // Fallback/recovery path in case the in-process precise timer misses the slot.
+                var fallbackRunAt = targetTime.AddSeconds(3);
+                if (fallbackRunAt < DateTimeOffset.UtcNow)
+                    fallbackRunAt = DateTimeOffset.UtcNow.AddSeconds(3);
+
+                _backgroundJobClient.Schedule<BookingService>(x => x.Booking(bookingInfo, CancellationToken.None), fallbackRunAt);
             }
         }
         catch (Exception ex) {

--- a/tests/TennisBooking.Tests/UnitTests.cs
+++ b/tests/TennisBooking.Tests/UnitTests.cs
@@ -54,8 +54,9 @@ public class UnitTests
 
         var bg = new Mock<IBackgroundJobClient>();
         bg.Setup(x => x.Create(It.IsAny<Job>(), It.IsAny<IState>())).Returns("job-id");
+        var precise = new Mock<IPreciseBookingScheduler>();
 
-        var svc = CreateBookingService(server.BaseUrl, out var telegramDb, out _, bg.Object);
+        var svc = CreateBookingService(server.BaseUrl, out var telegramDb, out _, bg.Object, precise.Object);
         telegramDb.TelegramConfigs.Add(new TelegramConfig { BotToken = "t", ChatId = 1 });
         telegramDb.SaveChanges();
 
@@ -73,6 +74,7 @@ public class UnitTests
         await svc.Preparation(cfg, true, CancellationToken.None);
 
         bg.Verify(x => x.Create(It.IsAny<Job>(), It.IsAny<IState>()), Times.Once);
+        precise.Verify(x => x.ScheduleBooking(It.IsAny<BookingInfo>()), Times.Once);
     }
 
     [Fact]
@@ -119,7 +121,8 @@ public class UnitTests
             NullLogger<BookingService>.Instance,
             Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }),
             tg,
-            Mock.Of<IBackgroundJobClient>());
+            Mock.Of<IBackgroundJobClient>(),
+            Mock.Of<IPreciseBookingScheduler>());
 
         var info = new BookingInfo
         {
@@ -259,18 +262,20 @@ public class UnitTests
         Hour = 10
     };
 
-    private static BookingService CreateBookingService(string apiBaseUrl, out ApplicationDbContext telegramDb, out IBackgroundJobClient bg, IBackgroundJobClient? bgOverride = null)
+    private static BookingService CreateBookingService(string apiBaseUrl, out ApplicationDbContext telegramDb, out IBackgroundJobClient bg, IBackgroundJobClient? bgOverride = null, IPreciseBookingScheduler? preciseOverride = null)
     {
         var tgHandler = new DelegateHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
         var dbOpts = new DbContextOptionsBuilder<ApplicationDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
         telegramDb = new ApplicationDbContext(dbOpts);
         var tg = new TelegramService(new HttpClient(tgHandler), telegramDb, NullLogger<TelegramService>.Instance);
         bg = bgOverride ?? Mock.Of<IBackgroundJobClient>();
+        var precise = preciseOverride ?? Mock.Of<IPreciseBookingScheduler>();
         return new BookingService(
             NullLogger<BookingService>.Instance,
             Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = apiBaseUrl }),
             tg,
-            bg);
+            bg,
+            precise);
     }
 
     private static DefaultHttpContext NewHttp()


### PR DESCRIPTION
## What changed
- Added interface + hosted scheduler service for precise booking trigger
- Preparation() now schedules:
  - in-process precise timer for near-zero jitter trigger at booking open time
  - Hangfire fallback run (+3s) for reliability/recovery
- Wired scheduler through DI
- Updated unit tests for new dependency and scheduling behavior

## Why
Keep Hangfire persistence/reliability while reducing latency/jitter versus polling-based scheduled trigger at the critical booking second.

## Notes
- No change to existing recurring preparation strategy
- Fallback still ensures booking attempt if in-process timer misses (restart/transient issue)