### PR TITLE
fix: improve Hangfire booking reliability

### DIFF
--- a/src/TennisBooking/Auth/HangfireBasicAuthFilter.cs
+++ b/src/TennisBooking/Auth/HangfireBasicAuthFilter.cs
@@ -30,9 +30,18 @@ public class HangfireBasicAuthFilter : IDashboardAuthorizationFilter
             return false;
         }
 
-        var credentials = Encoding.UTF8
-            .GetString(Convert.FromBase64String(header.ToString().Substring(6)))
-            .Split(':', 2);
+        string[] credentials;
+        try
+        {
+            credentials = Encoding.UTF8
+                .GetString(Convert.FromBase64String(header.ToString().Substring(6)))
+                .Split(':', 2);
+        }
+        catch (FormatException)
+        {
+            Challenge(http);
+            return false;
+        }
 
         if (credentials.Length == 2 &&
             credentials[0] == _user &&

--- a/src/TennisBooking/Program.cs
+++ b/src/TennisBooking/Program.cs
@@ -33,16 +33,16 @@ builder.Services.AddHangfire(config => config
     .UseSimpleAssemblyNameTypeSerializer()
     .UseRecommendedSerializerSettings()
     .UsePostgreSqlStorage(connString,
-        new PostgreSqlStorageOptions { SchemaName = "hangfire", QueuePollInterval = TimeSpan.FromSeconds(5) })
+        new PostgreSqlStorageOptions { SchemaName = "hangfire", QueuePollInterval = TimeSpan.FromSeconds(1) })
     .UseFilter(new AutomaticRetryAttribute
     {
-        Attempts        = 3,
-        DelaysInSeconds = new[] { 0, 0, 0 }
+        Attempts        = 2,
+        DelaysInSeconds = new[] { 2, 5 }
     })
 );
 builder.Services.AddHangfireServer(options =>
 {
-    options.SchedulePollingInterval = TimeSpan.FromMilliseconds(10);
+    options.SchedulePollingInterval = TimeSpan.FromSeconds(1);
 });
 builder.Services.AddSingleton<PreciseBookingScheduler>();
 builder.Services.AddSingleton<IPreciseBookingScheduler>(sp => sp.GetRequiredService<PreciseBookingScheduler>());

--- a/src/TennisBooking/Services/BookingService.cs
+++ b/src/TennisBooking/Services/BookingService.cs
@@ -1,11 +1,14 @@
 ﻿namespace TennisBooking.Services;
 
+using System.Collections.Concurrent;
 using System.Globalization;
 using Models;
 using Hangfire;
+using DAL;
 using DAL.Models;
 using System.Text.RegularExpressions;
 using System.Net;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Options;
 using System.Text;
@@ -21,8 +24,11 @@ public class BookingService {
     private const string CookieHeaderName = "Cookie";
     private const string ApplicationCookieName = "X-Skedda-ApplicationCookie";
     private const string CsrfCookieName = "X-Skedda-RequestVerificationCookie";
+    private static readonly ConcurrentDictionary<string, byte> BookingKeys = new();
+
     private readonly ILogger<BookingService> _logger;
     private readonly SkeddaOptions _opts;
+    private readonly ApplicationDbContext _db;
     private readonly IBackgroundJobClient _backgroundJobClient;
     private readonly TelegramService _telegram;
     private readonly IPreciseBookingScheduler _preciseBookingScheduler;
@@ -30,11 +36,13 @@ public class BookingService {
     public BookingService(
         ILogger<BookingService> logger,
         IOptions<SkeddaOptions> opts,
+        ApplicationDbContext db,
         TelegramService telegram,
         IBackgroundJobClient backgroundJobClient,
         IPreciseBookingScheduler preciseBookingScheduler) {
         _logger = logger;
         _opts = opts.Value;
+        _db = db;
         _backgroundJobClient = backgroundJobClient;
         _telegram = telegram;
         _preciseBookingScheduler = preciseBookingScheduler;
@@ -45,100 +53,24 @@ public class BookingService {
             _logger.LogError("UserConfig is null");
             return;
         }
-        var bookingDay = DateTimeOffset.UtcNow.AddDays(14);
-        var tz = TimeZoneInfo.FindSystemTimeZoneById("Europe/Kyiv");
-        var startTime = new DateTimeOffset(bookingDay.Year, bookingDay.Month, bookingDay.Day, userConfig.Hour, 0, 0, 0, tz.GetUtcOffset(bookingDay));
+
         try {
-            var handler = new HttpClientHandler { CookieContainer = new CookieContainer() };
-            var baseUri = new Uri(_opts.ApiBaseUrl);
-            using var client = new HttpClient(handler) { BaseAddress = baseUri };
+            var startTime = GetBookingStartTime(userConfig);
+            var bookingInfo = await PrepareBookingInfo(userConfig, startTime, ct);
 
-            var openLoginPage = await client.GetAsync(AccountLoginPath, ct);
-            openLoginPage.EnsureSuccessStatusCode();
-            var loginHtml = await openLoginPage.Content.ReadAsStringAsync(ct);
-            var requestVerificationToken = GetRequestVerificationToken(loginHtml);
-            var loginReq = new HttpRequestMessage(HttpMethod.Post, LoginPath);
-            loginReq.Headers.Add(CsrfHeaderName, requestVerificationToken);
-            loginReq.Headers.Add(CookieHeaderName,
-                $"{CsrfCookieName}={handler.CookieContainer.GetCookies(baseUri)[CsrfCookieName].Value}");
-
-            loginReq.Content = new StringContent(
-                JsonConvert.SerializeObject(new {
-                    login = new {
-                        arbitraryerrors = (object)null,
-                        username = userConfig.Username,
-                        password = userConfig.Password,
-                        rememberMe = false
-                    }
-                }),
-                Encoding.UTF8,
-                "application/json"
-            );
-            var loginResp = await client.SendAsync(loginReq, ct);
-            loginResp.EnsureSuccessStatusCode();
-
-            var csrfCookie = handler.CookieContainer.GetCookies(baseUri)[CsrfCookieName].Value;
-
-            var applicationCookie = handler.CookieContainer.GetCookies(baseUri)[ApplicationCookieName].Value;
-            var getBookingsReq = new HttpRequestMessage(HttpMethod.Get, GetBookingsPath);
-            getBookingsReq.Headers.Add(CsrfHeaderName, requestVerificationToken);
-            getBookingsReq.Headers.Add(CookieHeaderName,
-                $"{CsrfCookieName}={csrfCookie}; " +
-                $"{ApplicationCookieName}={applicationCookie}");
-            var getBookingsResp = await client.SendAsync(getBookingsReq, ct);
-            getBookingsResp.EnsureSuccessStatusCode();
-            requestVerificationToken = GetRequestVerificationToken(await getBookingsResp.Content.ReadAsStringAsync(ct));
-
-            var bookingBody = new {
-                booking = new {
-                    addConference = false,
-                    allowInviteOthers = false,
-                    arbitraryerrors = (object)null,
-                    attendees = new int[0],
-                    availabilityStatus = 1,
-                    chargeTransactionId = (object)null,
-                    checkInAudits = (object)null,
-                    createdDate = (object)null,
-                    customFields = new int[0],
-                    decoupleBooking = (object)null,
-                    decoupleDate = (object)null,
-                    end = startTime.AddHours(1).ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture),
-                    endOfLastOccurrence = (object)null,
-                    hideAttendees = true,
-                    lockInMargin = 1,
-                    paymentStatus = 0,
-                    piId = (object)null,
-                    price = 0,
-                    recurrenceRule = (object)null,
-                    spaces = new[] { userConfig.ResourceId },
-                    start = startTime.ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture),
-                    stripPrivateEventDetails = false,
-                    syncType = (object)null,
-                    title = (object)null,
-                    type = 1,
-                    unrecognizedOrganizer = false,
-                    venue = userConfig.Venue,
-                    venueuser = userConfig.VenueUser
-                }
-            };
-            var bookingInfo = new BookingInfo {
-                UserConfig = userConfig,
-                Body = bookingBody,
-                RequestVerificationToken = requestVerificationToken,
-                CsrfCookie = csrfCookie,
-                ApplicationCookie = applicationCookie,
-                StartTime = startTime,
-            };
             if (scheduleBookingJob) {
                 var targetTime = startTime.AddDays(-14);
                 _preciseBookingScheduler.ScheduleBooking(bookingInfo);
 
                 // Fallback/recovery path in case the in-process precise timer misses the slot.
+                // Only stable identifiers are persisted in Hangfire, not prepared cookies/tokens/passwords.
                 var fallbackRunAt = targetTime.AddSeconds(3);
                 if (fallbackRunAt < DateTimeOffset.UtcNow)
                     fallbackRunAt = DateTimeOffset.UtcNow.AddSeconds(3);
 
-                _backgroundJobClient.Schedule<BookingService>(x => x.Booking(bookingInfo, CancellationToken.None), fallbackRunAt);
+                _backgroundJobClient.Schedule<BookingService>(
+                    x => x.BookingFallback(userConfig.Id, startTime, CancellationToken.None),
+                    fallbackRunAt);
             }
         }
         catch (Exception ex) {
@@ -147,11 +79,28 @@ public class BookingService {
         }
     }
 
+    public async Task BookingFallback(int userConfigId, DateTimeOffset startTime, CancellationToken ct) {
+        var userConfig = await _db.UserConfigs.AsNoTracking().FirstOrDefaultAsync(x => x.Id == userConfigId, ct);
+        if (userConfig == null)
+            throw new InvalidOperationException($"UserConfig {userConfigId} not found.");
+
+        var bookingInfo = await PrepareBookingInfo(userConfig, startTime, ct);
+        await Booking(bookingInfo, ct);
+    }
+
+    [AutomaticRetry(Attempts = 0)]
     public async Task Booking(BookingInfo bookingInfo, CancellationToken ct) {
         if (bookingInfo == null) {
             _logger.LogError("BookingInfo is null");
             return;
         }
+
+        var bookingKey = BuildBookingKey(bookingInfo);
+        if (!BookingKeys.TryAdd(bookingKey, 0)) {
+            _logger.LogInformation("Skipping duplicate booking attempt for {BookingKey}", bookingKey);
+            return;
+        }
+
         try {
             var baseUri = new Uri(_opts.ApiBaseUrl);
             using var client = new HttpClient { BaseAddress = baseUri };
@@ -168,7 +117,7 @@ public class BookingService {
                 $"{ApplicationCookieName}={bookingInfo.ApplicationCookie}");
             var bookResp = await client.SendAsync(bookReq, ct);
             if (!bookResp.IsSuccessStatusCode) {
-                throw new HttpRequestException($"Response from Skedda {await bookResp.Content.ReadAsStringAsync()}");
+                throw new HttpRequestException($"Response from Skedda {await bookResp.Content.ReadAsStringAsync(ct)}");
             }
             bookResp.EnsureSuccessStatusCode();
             _logger.LogInformation("Booked court for user {ConfigId}", bookingInfo.UserConfig.Username);
@@ -180,10 +129,111 @@ public class BookingService {
             await _telegram.NotifyAsync(msg);
         }
         catch (Exception ex) {
+            BookingKeys.TryRemove(bookingKey, out _);
             _logger.LogError(ex, "Failed to book court for user {ConfigId}", bookingInfo.UserConfig.Username);
             throw;
         }
     }
+
+    private async Task<BookingInfo> PrepareBookingInfo(UserConfig userConfig, DateTimeOffset startTime, CancellationToken ct) {
+        var handler = new HttpClientHandler { CookieContainer = new CookieContainer() };
+        var baseUri = new Uri(_opts.ApiBaseUrl);
+        using var client = new HttpClient(handler) { BaseAddress = baseUri };
+
+        var openLoginPage = await client.GetAsync(AccountLoginPath, ct);
+        openLoginPage.EnsureSuccessStatusCode();
+        var loginHtml = await openLoginPage.Content.ReadAsStringAsync(ct);
+        var requestVerificationToken = GetRequestVerificationToken(loginHtml);
+        var loginReq = new HttpRequestMessage(HttpMethod.Post, LoginPath);
+        loginReq.Headers.Add(CsrfHeaderName, requestVerificationToken);
+        loginReq.Headers.Add(CookieHeaderName,
+            $"{CsrfCookieName}={handler.CookieContainer.GetCookies(baseUri)[CsrfCookieName].Value}");
+
+        loginReq.Content = new StringContent(
+            JsonConvert.SerializeObject(new {
+                login = new {
+                    arbitraryerrors = (object)null,
+                    username = userConfig.Username,
+                    password = userConfig.Password,
+                    rememberMe = false
+                }
+            }),
+            Encoding.UTF8,
+            "application/json"
+        );
+        var loginResp = await client.SendAsync(loginReq, ct);
+        loginResp.EnsureSuccessStatusCode();
+
+        var csrfCookie = handler.CookieContainer.GetCookies(baseUri)[CsrfCookieName].Value;
+        var applicationCookie = handler.CookieContainer.GetCookies(baseUri)[ApplicationCookieName].Value;
+        var getBookingsReq = new HttpRequestMessage(HttpMethod.Get, GetBookingsPath);
+        getBookingsReq.Headers.Add(CsrfHeaderName, requestVerificationToken);
+        getBookingsReq.Headers.Add(CookieHeaderName,
+            $"{CsrfCookieName}={csrfCookie}; " +
+            $"{ApplicationCookieName}={applicationCookie}");
+        var getBookingsResp = await client.SendAsync(getBookingsReq, ct);
+        getBookingsResp.EnsureSuccessStatusCode();
+        requestVerificationToken = GetRequestVerificationToken(await getBookingsResp.Content.ReadAsStringAsync(ct));
+
+        var bookingBody = new {
+            booking = new {
+                addConference = false,
+                allowInviteOthers = false,
+                arbitraryerrors = (object)null,
+                attendees = new int[0],
+                availabilityStatus = 1,
+                chargeTransactionId = (object)null,
+                checkInAudits = (object)null,
+                createdDate = (object)null,
+                customFields = new int[0],
+                decoupleBooking = (object)null,
+                decoupleDate = (object)null,
+                end = startTime.AddHours(1).ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture),
+                endOfLastOccurrence = (object)null,
+                hideAttendees = true,
+                lockInMargin = 1,
+                paymentStatus = 0,
+                piId = (object)null,
+                price = 0,
+                recurrenceRule = (object)null,
+                spaces = new[] { userConfig.ResourceId },
+                start = startTime.ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture),
+                stripPrivateEventDetails = false,
+                syncType = (object)null,
+                title = (object)null,
+                type = 1,
+                unrecognizedOrganizer = false,
+                venue = userConfig.Venue,
+                venueuser = userConfig.VenueUser
+            }
+        };
+
+        return new BookingInfo {
+            UserConfig = userConfig,
+            Body = bookingBody,
+            RequestVerificationToken = requestVerificationToken,
+            CsrfCookie = csrfCookie,
+            ApplicationCookie = applicationCookie,
+            StartTime = startTime,
+        };
+    }
+
+    private static DateTimeOffset GetBookingStartTime(UserConfig userConfig) {
+        var bookingDay = DateTimeOffset.UtcNow.AddDays(14);
+        var tz = TimeZoneInfo.FindSystemTimeZoneById("Europe/Kyiv");
+        return new DateTimeOffset(
+            bookingDay.Year,
+            bookingDay.Month,
+            bookingDay.Day,
+            userConfig.Hour,
+            0,
+            0,
+            0,
+            tz.GetUtcOffset(bookingDay));
+    }
+
+    private static string BuildBookingKey(BookingInfo bookingInfo)
+        => $"{bookingInfo.UserConfig.Username}:{bookingInfo.UserConfig.ResourceId}:{bookingInfo.StartTime.ToUnixTimeMilliseconds()}";
 
     private string GetRequestVerificationToken(string loginHtml) {
         var match = Regex.Match(

--- a/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
+++ b/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
@@ -227,7 +227,7 @@ public sealed class BookingPostgresIntegrationTests
         await connection.OpenAsync();
 
         await using var command = new NpgsqlCommand("""
-            select j.invocationdata, j.arguments, coalesce(s.name, '') || ' ' || coalesce(s.data, '') as statedata
+            select j.invocationdata, j.arguments, coalesce(s.name, '') || ' ' || coalesce(s.data::text, '') as statedata
             from hangfire.job j
             left join hangfire.state s on s.jobid = j.id
             order by j.id desc, s.id desc

--- a/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
+++ b/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
@@ -1,0 +1,369 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using Hangfire;
+using Hangfire.PostgreSql;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Npgsql;
+using TennisBooking.DAL;
+using TennisBooking.DAL.Models;
+using TennisBooking.Models;
+using TennisBooking.Options;
+using TennisBooking.Services;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace TennisBooking.Tests.Integration;
+
+public sealed class BookingPostgresIntegrationTests
+{
+    [DockerFact]
+    public async Task Preparation_PersistsScheduledFallback_WithMinimalArgumentsInHangfirePostgres()
+    {
+        await using var postgres = await StartPostgresAsync();
+        var connectionString = postgres.GetConnectionString();
+
+        await using var db = await CreateMigratedDbAsync(connectionString);
+        using var skedda = new FakeSkeddaServer();
+        skedda.Enqueue(HttpMethod.Get, "/account/login", ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            ctx.Response.Headers.Add("Set-Cookie", "X-Skedda-RequestVerificationCookie=csrf-cookie; Path=/");
+            return "<input name=\"__RequestVerificationToken\" type=\"hidden\" value=\"token-1\" />";
+        });
+        skedda.Enqueue(HttpMethod.Post, "/logins", ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            ctx.Response.Headers.Add("Set-Cookie", "X-Skedda-ApplicationCookie=app-cookie; Path=/");
+            return "{}";
+        });
+        skedda.Enqueue(HttpMethod.Get, "/booking", ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            return "<input name=\"__RequestVerificationToken\" type=\"hidden\" value=\"token-2\" />";
+        });
+
+        var storage = new PostgreSqlStorage(connectionString, _ => { }, new PostgreSqlStorageOptions
+        {
+            SchemaName = "hangfire",
+            QueuePollInterval = TimeSpan.FromSeconds(1)
+        });
+        var backgroundJobs = new BackgroundJobClient(storage);
+        var precise = new Mock<IPreciseBookingScheduler>();
+        var service = CreateBookingService(skedda.BaseUrl, db, backgroundJobs, precise.Object);
+
+        var userConfig = NewConfig("postgres-schedule");
+        db.UserConfigs.Add(userConfig);
+        db.TelegramConfigs.Add(new TelegramConfig { BotToken = "telegram-token", ChatId = 123 });
+        await db.SaveChangesAsync();
+
+        await service.Preparation(userConfig, scheduleBookingJob: true, CancellationToken.None);
+
+        precise.Verify(x => x.ScheduleBooking(It.IsAny<BookingInfo>()), Times.Once);
+
+        var persistedJob = await ReadLatestHangfireJobAsync(connectionString);
+        Assert.Contains(nameof(BookingService.BookingFallback), persistedJob.InvocationData);
+        Assert.Contains(userConfig.Id.ToString(), persistedJob.Arguments);
+        Assert.Contains("Scheduled", persistedJob.StateData);
+
+        Assert.DoesNotContain(nameof(BookingInfo), persistedJob.Arguments, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("password", persistedJob.Arguments, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(userConfig.Password, persistedJob.Arguments, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("csrf-cookie", persistedJob.Arguments, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("app-cookie", persistedJob.Arguments, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("token-1", persistedJob.Arguments, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("token-2", persistedJob.Arguments, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [DockerFact]
+    public async Task BookingFallback_LoadsUserConfigFromRealPostgres_AndBooksOnce()
+    {
+        await using var postgres = await StartPostgresAsync();
+        var connectionString = postgres.GetConnectionString();
+
+        await using var db = await CreateMigratedDbAsync(connectionString);
+        using var skedda = new FakeSkeddaServer();
+        var bookingPosts = 0;
+        EnqueuePreparationResponses(skedda);
+        skedda.Enqueue(HttpMethod.Post, "/bookings", ctx =>
+        {
+            bookingPosts++;
+            ctx.Response.StatusCode = 200;
+            return "{}";
+        });
+
+        var userConfig = NewConfig("postgres-fallback");
+        db.UserConfigs.Add(userConfig);
+        db.TelegramConfigs.Add(new TelegramConfig { BotToken = "telegram-token", ChatId = 123 });
+        await db.SaveChangesAsync();
+
+        var service = CreateBookingService(skedda.BaseUrl, db);
+        var startTime = new DateTimeOffset(2030, 1, 1, userConfig.Hour, 0, 0, TimeSpan.Zero);
+
+        await service.BookingFallback(userConfig.Id, startTime, CancellationToken.None);
+
+        Assert.Equal(1, bookingPosts);
+    }
+
+    [DockerFact]
+    public async Task BookingFallback_DoesNotDoublePost_WhenPreciseBookingAlreadyPostedSameSlot()
+    {
+        await using var postgres = await StartPostgresAsync();
+        var connectionString = postgres.GetConnectionString();
+
+        await using var db = await CreateMigratedDbAsync(connectionString);
+        using var skedda = new FakeSkeddaServer();
+        var bookingPosts = 0;
+
+        skedda.Enqueue(HttpMethod.Post, "/bookings", ctx =>
+        {
+            bookingPosts++;
+            ctx.Response.StatusCode = 200;
+            return "{}";
+        });
+        EnqueuePreparationResponses(skedda);
+
+        var userConfig = NewConfig("postgres-dedupe");
+        db.UserConfigs.Add(userConfig);
+        db.TelegramConfigs.Add(new TelegramConfig { BotToken = "telegram-token", ChatId = 123 });
+        await db.SaveChangesAsync();
+
+        var service = CreateBookingService(skedda.BaseUrl, db);
+        var startTime = new DateTimeOffset(2030, 1, 1, userConfig.Hour, 0, 0, TimeSpan.Zero);
+
+        await service.Booking(new BookingInfo
+        {
+            UserConfig = userConfig,
+            Body = new { booking = new { spaces = new[] { userConfig.ResourceId } } },
+            RequestVerificationToken = "token",
+            CsrfCookie = "csrf",
+            ApplicationCookie = "app",
+            StartTime = startTime
+        }, CancellationToken.None);
+        await service.BookingFallback(userConfig.Id, startTime, CancellationToken.None);
+
+        Assert.Equal(1, bookingPosts);
+    }
+
+    private static async Task<PostgreSqlContainer> StartPostgresAsync()
+    {
+        var postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:16-alpine")
+            .WithDatabase("tennisbooking_tests")
+            .WithUsername("postgres")
+            .WithPassword("postgres")
+            .Build();
+
+        await postgres.StartAsync();
+        return postgres;
+    }
+
+    private static async Task<ApplicationDbContext> CreateMigratedDbAsync(string connectionString)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(connectionString)
+            .Options;
+        var db = new ApplicationDbContext(options);
+        await db.Database.MigrateAsync();
+        return db;
+    }
+
+    private static BookingService CreateBookingService(
+        string apiBaseUrl,
+        ApplicationDbContext db,
+        IBackgroundJobClient? backgroundJobs = null,
+        IPreciseBookingScheduler? precise = null)
+    {
+        var telegramHandler = new DelegateHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        var telegram = new TelegramService(new HttpClient(telegramHandler), db, NullLogger<TelegramService>.Instance);
+
+        return new BookingService(
+            NullLogger<BookingService>.Instance,
+            Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = apiBaseUrl }),
+            db,
+            telegram,
+            backgroundJobs ?? Mock.Of<IBackgroundJobClient>(),
+            precise ?? Mock.Of<IPreciseBookingScheduler>());
+    }
+
+    private static UserConfig NewConfig(string usernamePrefix) => new()
+    {
+        Username = $"{usernamePrefix}-{Guid.NewGuid():N}",
+        Password = $"secret-password-{Guid.NewGuid():N}",
+        ResourceId = $"resource-{Guid.NewGuid():N}",
+        Venue = "venue",
+        VenueUser = "venue-user",
+        DayOfWeek = DayOfWeek.Monday,
+        Hour = 10
+    };
+
+    private static void EnqueuePreparationResponses(FakeSkeddaServer skedda)
+    {
+        skedda.Enqueue(HttpMethod.Get, "/account/login", ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            ctx.Response.Headers.Add("Set-Cookie", "X-Skedda-RequestVerificationCookie=csrf-cookie; Path=/");
+            return "<input name=\"__RequestVerificationToken\" type=\"hidden\" value=\"token-1\" />";
+        });
+        skedda.Enqueue(HttpMethod.Post, "/logins", ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            ctx.Response.Headers.Add("Set-Cookie", "X-Skedda-ApplicationCookie=app-cookie; Path=/");
+            return "{}";
+        });
+        skedda.Enqueue(HttpMethod.Get, "/booking", ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            return "<input name=\"__RequestVerificationToken\" type=\"hidden\" value=\"token-2\" />";
+        });
+    }
+
+    private static async Task<(string InvocationData, string Arguments, string StateData)> ReadLatestHangfireJobAsync(string connectionString)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+
+        await using var command = new NpgsqlCommand("""
+            select j.invocationdata, j.arguments, coalesce(s.name, '') || ' ' || coalesce(s.data, '') as statedata
+            from hangfire.job j
+            left join hangfire.state s on s.jobid = j.id
+            order by j.id desc, s.id desc
+            limit 1;
+            """, connection);
+        await using var reader = await command.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync(), "Expected Hangfire to persist one scheduled job.");
+        return (reader.GetString(0), reader.GetString(1), reader.GetString(2));
+    }
+
+    private sealed class DockerFactAttribute : FactAttribute
+    {
+        public DockerFactAttribute()
+        {
+            if (!DockerAvailable())
+            {
+                Skip = "Docker is not available; skipping Testcontainers PostgreSQL integration test.";
+            }
+        }
+
+        private static bool DockerAvailable()
+        {
+            try
+            {
+                using var process = Process.Start(new ProcessStartInfo
+                {
+                    FileName = "docker",
+                    Arguments = "version --format {{.Server.Version}}",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false
+                });
+                if (process == null)
+                    return false;
+
+                return process.WaitForExit(5_000) && process.ExitCode == 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    private sealed class DelegateHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _fn;
+        public DelegateHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> fn) => _fn = fn;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) => _fn(request, cancellationToken);
+    }
+
+    private sealed class FakeSkeddaServer : IDisposable
+    {
+        private readonly HttpListener _listener;
+        private readonly Queue<(string method, string path, Func<HttpListenerContext, string> response)> _responses = new();
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _loop;
+
+        public string BaseUrl { get; }
+
+        public FakeSkeddaServer()
+        {
+            var port = GetFreePort();
+            BaseUrl = $"http://127.0.0.1:{port}";
+            _listener = new HttpListener();
+            _listener.Prefixes.Add(BaseUrl + "/");
+            _listener.Start();
+            _loop = Task.Run(LoopAsync);
+        }
+
+        public void Enqueue(HttpMethod method, string path, Func<HttpListenerContext, string> response)
+            => _responses.Enqueue((method.Method, path, response));
+
+        private async Task LoopAsync()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                HttpListenerContext? ctx = null;
+                try
+                {
+                    ctx = await _listener.GetContextAsync();
+                    if (_responses.Count == 0)
+                    {
+                        ctx.Response.StatusCode = 500;
+                        await WriteAsync(ctx.Response, "No response configured");
+                        continue;
+                    }
+
+                    var expected = _responses.Dequeue();
+                    ctx.Response.StatusCode = 200;
+                    Assert.Equal(expected.method, ctx.Request.HttpMethod);
+                    Assert.Equal(expected.path, ctx.Request.Url!.AbsolutePath);
+                    var body = expected.response(ctx);
+                    await WriteAsync(ctx.Response, body);
+                }
+                catch when (_cts.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch
+                {
+                    if (ctx != null)
+                    {
+                        ctx.Response.StatusCode = 500;
+                        ctx.Response.Close();
+                    }
+                    throw;
+                }
+            }
+        }
+
+        private static async Task WriteAsync(HttpListenerResponse response, string body)
+        {
+            var bytes = Encoding.UTF8.GetBytes(body);
+            response.ContentType = "text/html";
+            response.ContentLength64 = bytes.Length;
+            await response.OutputStream.WriteAsync(bytes);
+            response.Close();
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+            _listener.Close();
+            try { _loop.GetAwaiter().GetResult(); } catch { }
+            _cts.Dispose();
+        }
+
+        private static int GetFreePort()
+        {
+            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+}

--- a/tests/TennisBooking.Tests/TennisBooking.Tests.csproj
+++ b/tests/TennisBooking.Tests/TennisBooking.Tests.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/TennisBooking.Tests/UnitTests.cs
+++ b/tests/TennisBooking.Tests/UnitTests.cs
@@ -71,10 +71,94 @@ public class UnitTests
             Hour = 10
         };
 
+        Job? scheduledJob = null;
+        bg.Invocations.Clear();
+        bg.Setup(x => x.Create(It.IsAny<Job>(), It.IsAny<IState>()))
+            .Callback<Job, IState>((job, _) => scheduledJob = job)
+            .Returns("job-id");
+
         await svc.Preparation(cfg, true, CancellationToken.None);
 
         bg.Verify(x => x.Create(It.IsAny<Job>(), It.IsAny<IState>()), Times.Once);
         precise.Verify(x => x.ScheduleBooking(It.IsAny<BookingInfo>()), Times.Once);
+        Assert.NotNull(scheduledJob);
+        Assert.Equal(nameof(BookingService.BookingFallback), scheduledJob!.Method.Name);
+        Assert.DoesNotContain(scheduledJob.Args, arg => arg is BookingInfo);
+    }
+
+    [Fact]
+    public async Task Booking_DoesNotPostTwice_ForSameSlot()
+    {
+        using var skedda = new FakeSkeddaServer();
+        var bookingPosts = 0;
+        skedda.Enqueue(HttpMethod.Post, "/bookings", ctx =>
+        {
+            bookingPosts++;
+            ctx.Response.StatusCode = 200;
+            return "{}";
+        });
+
+        var svc = CreateBookingService(skedda.BaseUrl, out _, out _);
+        var info = new BookingInfo
+        {
+            UserConfig = BasicConfig(),
+            Body = new { },
+            RequestVerificationToken = "t",
+            CsrfCookie = "c",
+            ApplicationCookie = "a",
+            StartTime = new DateTimeOffset(2030, 1, 1, 10, 0, 0, TimeSpan.Zero)
+        };
+
+        await svc.Booking(info, CancellationToken.None);
+        await svc.Booking(info, CancellationToken.None);
+
+        Assert.Equal(1, bookingPosts);
+    }
+
+    [Fact]
+    public async Task BookingFallback_LoadsConfigAndBooksWithoutSensitiveHangfireArgs()
+    {
+        using var server = new FakeSkeddaServer();
+        server.Enqueue(HttpMethod.Get, "/account/login", ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            ctx.Response.Headers.Add("Set-Cookie", "X-Skedda-RequestVerificationCookie=csrf-cookie; Path=/");
+            return "<input name=\"__RequestVerificationToken\" type=\"hidden\" value=\"token-1\" />";
+        });
+        server.Enqueue(HttpMethod.Post, "/logins", ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            ctx.Response.Headers.Add("Set-Cookie", "X-Skedda-ApplicationCookie=app-cookie; Path=/");
+            return "{}";
+        });
+        server.Enqueue(HttpMethod.Get, "/booking", ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            return "<input name=\"__RequestVerificationToken\" type=\"hidden\" value=\"token-2\" />";
+        });
+        server.Enqueue(HttpMethod.Post, "/bookings", ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            return "{}";
+        });
+
+        var svc = CreateBookingService(server.BaseUrl, out var db, out _);
+        var cfg = BasicConfig();
+        cfg.Id = 42;
+        db.UserConfigs.Add(cfg);
+        db.SaveChanges();
+
+        var startTime = new DateTimeOffset(2030, 1, 1, cfg.Hour, 0, 0, TimeSpan.Zero);
+        await svc.BookingFallback(cfg.Id, startTime, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task BookingFallback_Throws_WhenUserConfigMissing()
+    {
+        var svc = CreateBookingService("http://127.0.0.1:65534", out _, out _);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            svc.BookingFallback(999, DateTimeOffset.UtcNow, CancellationToken.None));
     }
 
     [Fact]
@@ -120,6 +204,7 @@ public class UnitTests
         var svc = new BookingService(
             NullLogger<BookingService>.Instance,
             Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }),
+            db,
             tg,
             Mock.Of<IBackgroundJobClient>(),
             Mock.Of<IPreciseBookingScheduler>());
@@ -221,6 +306,10 @@ public class UnitTests
         httpBadCreds.Request.Headers["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes("user:nope"));
         Assert.False(filter.Authorize(new AspNetCoreDashboardContext(storage, options, httpBadCreds)));
 
+        var httpBadBase64 = NewHttp();
+        httpBadBase64.Request.Headers["Authorization"] = "Basic not-base64";
+        Assert.False(filter.Authorize(new AspNetCoreDashboardContext(storage, options, httpBadBase64)));
+
         var httpGood = NewHttp();
         httpGood.Request.Headers["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes("user:pass"));
         Assert.True(filter.Authorize(new AspNetCoreDashboardContext(storage, options, httpGood)));
@@ -273,6 +362,7 @@ public class UnitTests
         return new BookingService(
             NullLogger<BookingService>.Instance,
             Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = apiBaseUrl }),
+            telegramDb,
             tg,
             bg,
             precise);


### PR DESCRIPTION
## Summary
- Tune Hangfire polling/retry settings for PostgreSQL-backed fallback jobs
- Disable automatic retries for the non-idempotent booking POST
- Avoid persisting prepared `BookingInfo` cookies/tokens/password-derived data in Hangfire job args
- Add a duplicate booking guard so precise timer + fallback do not POST the same slot twice in-process
- Harden Hangfire dashboard Basic auth against malformed Base64 headers

## Test Plan
- `dotnet test tests/TennisBooking.Tests/TennisBooking.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:Threshold=100 /p:ThresholdType=line /p:ThresholdStat=total --logger 'console;verbosity=minimal'`
- `dotnet build TennisBooking.sln --configuration Release --no-restore`

## Notes
The duplicate guard is process-local and prevents the immediate precise/fallback double-submit path. A future improvement could persist booking attempt state in PostgreSQL for cross-restart deduplication.
