### PR TITLE
Support nested Dokploy Docker context

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ docker run -d --name tennisbooking -p 5000:5000 \
   tennisbooking
 ```
 
-For Dokploy, set the build context/root directory to the repository root. The
-Dockerfile depends on `Directory.Packages.props` and the sibling projects under
-`src/`, so `src/TennisBooking` cannot be used as the Docker build context.
+For Dokploy, prefer the repository root as the build context and `Dockerfile` as
+the Dockerfile path. If the app is configured with `src/TennisBooking` as the
+build context, use `src/TennisBooking/Dockerfile`; it fetches the full repository
+inside the build stage because Docker cannot read files above the build context.
 
 The application will be available at `http://localhost:5000` (or port 80 when deployed).
 

--- a/src/TennisBooking/Dockerfile
+++ b/src/TennisBooking/Dockerfile
@@ -1,16 +1,13 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
-COPY Directory.Packages.props ./
-COPY TennisBooking.slnx ./
-COPY src/TennisBooking.Domain/TennisBooking.Domain.csproj src/TennisBooking.Domain/
-COPY src/TennisBooking.Application/TennisBooking.Application.csproj src/TennisBooking.Application/
-COPY src/TennisBooking.Infrastructure/TennisBooking.Infrastructure.csproj src/TennisBooking.Infrastructure/
-COPY src/TennisBooking/TennisBooking.csproj src/TennisBooking/
-
+# This Dockerfile exists for hosts configured with src/TennisBooking as the
+# Docker build context. That context cannot see the solution root, so fetch the
+# full repository inside the build stage.
+ARG GIT_REPOSITORY=https://github.com/yaroslavshparuk/TennisBooking.git
+ARG GIT_REF=master
+RUN git clone --depth 1 --branch "$GIT_REF" "$GIT_REPOSITORY" .
 RUN dotnet restore TennisBooking.slnx --disable-parallel
-
-COPY . .
 RUN dotnet publish src/TennisBooking/TennisBooking.csproj -c Release -o /app/publish --no-restore
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0


### PR DESCRIPTION
## Summary
- update src/TennisBooking/Dockerfile to support Dokploy builds where src/TennisBooking is the Docker context
- clone the full repository in the build stage so central package management and sibling projects are available
- clarify both supported Dokploy configurations in README

## Verification
- dotnet build TennisBooking.slnx -v:minimal
- docker build -f src/TennisBooking/Dockerfile -t tennisbooking:nested-dokploy src/TennisBooking