### PR TITLE
Split liveness and readiness health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Dockerfile depends on `Directory.Packages.props` and the sibling projects under
 `src/`, so `src/TennisBooking` cannot be used as the Docker build context.
 
 The application will be available at `http://localhost:5000` (or port 80 when deployed).
+Use `/health` for container liveness checks. Use `/health/ready` for the deeper
+readiness check that verifies PostgreSQL and booking preparation.
 
 ## Configuration
 

--- a/src/TennisBooking/Program.cs
+++ b/src/TennisBooking/Program.cs
@@ -1,5 +1,6 @@
 using Hangfire;
 using Hangfire.PostgreSql;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using OpenTelemetry.Logs;
@@ -129,7 +130,11 @@ app.UseHangfireDashboard("/hangfire", new DashboardOptions
 app.UseEndpoints(endpoints => {
     endpoints.MapControllers();
     endpoints.MapHangfireDashboard();
-    endpoints.MapHealthChecks("/health");
+    endpoints.MapHealthChecks("/health", new HealthCheckOptions
+    {
+        Predicate = _ => false
+    });
+    endpoints.MapHealthChecks("/health/ready");
 });
 using (var scope = app.Services.CreateScope()) {
     var scheduler = scope.ServiceProvider.GetRequiredService<ScheduleBookingsUseCase>();


### PR DESCRIPTION
## Summary
- make /health a lightweight liveness endpoint for deployment probes
- keep PostgreSQL and booking preparation checks on /health/ready
- document the two health-check endpoints

## Verification
- dotnet restore TennisBooking.slnx --disable-parallel
- dotnet build TennisBooking.slnx --no-restore
- dotnet test TennisBooking.slnx --no-restore