### PR TITLE
Fix Hangfire recurring job assembly resolution

### DIFF
--- a/src/TennisBooking/TennisBooking.csproj
+++ b/src/TennisBooking/TennisBooking.csproj
@@ -36,9 +36,7 @@
 
     <ItemGroup>
       <ProjectReference Include="../TennisBooking.Infrastructure/TennisBooking.Infrastructure.csproj" />
-      <Reference Include="TennisBooking.Application">
-        <HintPath>../TennisBooking.Application/bin/$(Configuration)/net10.0/TennisBooking.Application.dll</HintPath>
-      </Reference>
+      <ProjectReference Include="../TennisBooking.Application/TennisBooking.Application.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- replace binary `HintPath` reference to `TennisBooking.Application.dll` with a proper project reference
- ensure app publish/build output consistently contains `TennisBooking.Application` so Hangfire can resolve recurring job types at runtime

## Problem
After rearchitecture, Hangfire recurring job deserialization failed with:
`System.IO.FileNotFoundException: Could not resolve assembly 'TennisBooking.Application'`

## Validation
- code change is isolated to `src/TennisBooking/TennisBooking.csproj`
- branch pushed and ready for review
