### PR TITLE
Run EF Core migrations on every application startup

### DIFF
--- a/src/TennisBooking/Program.cs
+++ b/src/TennisBooking/Program.cs
@@ -119,6 +119,12 @@ builder.Logging.AddOpenTelemetry(logging =>
 
 var app = builder.Build();
 
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    await db.Database.MigrateAsync();
+}
+
 app.UseRouting();
 app.UseHangfireDashboard("/hangfire", new DashboardOptions
 {


### PR DESCRIPTION
## Summary
- apply pending EF Core migrations automatically during application startup
- create a service scope before app pipeline setup and call ApplicationDbContext.Database.MigrateAsync()

## Validation
- dotnet build src/TennisBooking/TennisBooking.csproj
