### PR TITLE
Add Telegram long-polling /cancel flow

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/src/TennisBooking.Application/Abstractions/BookingCancellationLink.cs
+++ b/src/TennisBooking.Application/Abstractions/BookingCancellationLink.cs
@@ -1,0 +1,12 @@
+using TennisBooking.Domain.Booking;
+
+namespace TennisBooking.Application.Abstractions;
+
+public sealed record BookingCancellationLink(
+    BookingUserConfig UserConfig,
+    BookingSlot Slot,
+    long ChatId,
+    int TelegramMessageId,
+    string SkeddaBookingId,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset? CancelledAtUtc);

--- a/src/TennisBooking.Application/Abstractions/IBookingCancellationLinkRepository.cs
+++ b/src/TennisBooking.Application/Abstractions/IBookingCancellationLinkRepository.cs
@@ -1,0 +1,18 @@
+using TennisBooking.Domain.Booking;
+
+namespace TennisBooking.Application.Abstractions;
+
+public interface IBookingCancellationLinkRepository
+{
+    Task SaveAsync(
+        BookingUserConfig userConfig,
+        BookingSlot slot,
+        long chatId,
+        int telegramMessageId,
+        string skeddaBookingId,
+        CancellationToken cancellationToken);
+
+    Task<BookingCancellationLink?> GetByReplyAsync(long chatId, int repliedTelegramMessageId, CancellationToken cancellationToken);
+
+    Task<bool> TryMarkCancelledAsync(long chatId, int repliedTelegramMessageId, int cancelRequestMessageId, CancellationToken cancellationToken);
+}

--- a/src/TennisBooking.Application/Abstractions/INotificationSender.cs
+++ b/src/TennisBooking.Application/Abstractions/INotificationSender.cs
@@ -4,5 +4,10 @@ namespace TennisBooking.Application.Abstractions;
 
 public interface INotificationSender
 {
-    Task NotifyBookingSucceededAsync(BookingUserConfig userConfig, BookingSlot slot, CancellationToken cancellationToken);
+    Task<TelegramNotificationResult> NotifyBookingSucceededAsync(
+        BookingUserConfig userConfig,
+        BookingSlot slot,
+        CancellationToken cancellationToken);
+
+    Task NotifyMessageAsync(string message, CancellationToken cancellationToken);
 }

--- a/src/TennisBooking.Application/Abstractions/ISkeddaClient.cs
+++ b/src/TennisBooking.Application/Abstractions/ISkeddaClient.cs
@@ -6,5 +6,6 @@ namespace TennisBooking.Application.Abstractions;
 public interface ISkeddaClient
 {
     Task<PreparedBooking> PrepareBookingAsync(BookingUserConfig userConfig, BookingSlot slot, CancellationToken cancellationToken);
-    Task BookAsync(PreparedBooking booking, CancellationToken cancellationToken);
+    Task<SkeddaBookingResult> BookAsync(PreparedBooking booking, CancellationToken cancellationToken);
+    Task CancelAsync(PreparedBooking booking, string bookingId, CancellationToken cancellationToken);
 }

--- a/src/TennisBooking.Application/Abstractions/ITelegramPollingStateRepository.cs
+++ b/src/TennisBooking.Application/Abstractions/ITelegramPollingStateRepository.cs
@@ -1,0 +1,7 @@
+namespace TennisBooking.Application.Abstractions;
+
+public interface ITelegramPollingStateRepository
+{
+    Task<long?> GetLastProcessedUpdateIdAsync(CancellationToken cancellationToken);
+    Task SaveLastProcessedUpdateIdAsync(long updateId, CancellationToken cancellationToken);
+}

--- a/src/TennisBooking.Application/Abstractions/SkeddaBookingResult.cs
+++ b/src/TennisBooking.Application/Abstractions/SkeddaBookingResult.cs
@@ -1,0 +1,3 @@
+namespace TennisBooking.Application.Abstractions;
+
+public sealed record SkeddaBookingResult(string BookingId);

--- a/src/TennisBooking.Application/Abstractions/TelegramNotificationResult.cs
+++ b/src/TennisBooking.Application/Abstractions/TelegramNotificationResult.cs
@@ -1,0 +1,3 @@
+namespace TennisBooking.Application.Abstractions;
+
+public sealed record TelegramNotificationResult(long ChatId, int MessageId);

--- a/src/TennisBooking.Application/Booking/ExecuteBookingUseCase.cs
+++ b/src/TennisBooking.Application/Booking/ExecuteBookingUseCase.cs
@@ -7,15 +7,18 @@ public sealed class ExecuteBookingUseCase
     private readonly ISkeddaClient _skeddaClient;
     private readonly INotificationSender _notificationSender;
     private readonly IBookingDeduplicationStore _deduplicationStore;
+    private readonly IBookingCancellationLinkRepository _bookingCancellationLinkRepository;
 
     public ExecuteBookingUseCase(
         ISkeddaClient skeddaClient,
         INotificationSender notificationSender,
-        IBookingDeduplicationStore deduplicationStore)
+        IBookingDeduplicationStore deduplicationStore,
+        IBookingCancellationLinkRepository bookingCancellationLinkRepository)
     {
         _skeddaClient = skeddaClient;
         _notificationSender = notificationSender;
         _deduplicationStore = deduplicationStore;
+        _bookingCancellationLinkRepository = bookingCancellationLinkRepository;
     }
 
     public async Task ExecuteAsync(PreparedBooking? booking, CancellationToken cancellationToken)
@@ -29,8 +32,15 @@ public sealed class ExecuteBookingUseCase
 
         try
         {
-            await _skeddaClient.BookAsync(booking, cancellationToken);
-            await _notificationSender.NotifyBookingSucceededAsync(booking.UserConfig, booking.Slot, cancellationToken);
+            var bookResult = await _skeddaClient.BookAsync(booking, cancellationToken);
+            var telegramResult = await _notificationSender.NotifyBookingSucceededAsync(booking.UserConfig, booking.Slot, cancellationToken);
+            await _bookingCancellationLinkRepository.SaveAsync(
+                booking.UserConfig,
+                booking.Slot,
+                telegramResult.ChatId,
+                telegramResult.MessageId,
+                bookResult.BookingId,
+                cancellationToken);
         }
         catch
         {

--- a/src/TennisBooking.Application/Booking/ExecuteBookingUseCase.cs
+++ b/src/TennisBooking.Application/Booking/ExecuteBookingUseCase.cs
@@ -1,4 +1,5 @@
 using TennisBooking.Application.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace TennisBooking.Application.Booking;
 
@@ -8,32 +9,54 @@ public sealed class ExecuteBookingUseCase
     private readonly INotificationSender _notificationSender;
     private readonly IBookingDeduplicationStore _deduplicationStore;
     private readonly IBookingCancellationLinkRepository _bookingCancellationLinkRepository;
+    private readonly ILogger<ExecuteBookingUseCase> _logger;
 
     public ExecuteBookingUseCase(
         ISkeddaClient skeddaClient,
         INotificationSender notificationSender,
         IBookingDeduplicationStore deduplicationStore,
-        IBookingCancellationLinkRepository bookingCancellationLinkRepository)
+        IBookingCancellationLinkRepository bookingCancellationLinkRepository,
+        ILogger<ExecuteBookingUseCase> logger)
     {
         _skeddaClient = skeddaClient;
         _notificationSender = notificationSender;
         _deduplicationStore = deduplicationStore;
         _bookingCancellationLinkRepository = bookingCancellationLinkRepository;
+        _logger = logger;
     }
 
     public async Task ExecuteAsync(PreparedBooking? booking, CancellationToken cancellationToken)
     {
         if (booking is null)
+        {
+            _logger.LogInformation("Execute booking called with null prepared booking");
             return;
+        }
 
         var bookingKey = BuildBookingKey(booking);
         if (!_deduplicationStore.TryBegin(bookingKey))
+        {
+            _logger.LogInformation("Skipping duplicate booking execution for key {BookingKey}", bookingKey);
             return;
+        }
 
         try
         {
+            _logger.LogInformation(
+                "Executing booking for user {Username}, resource {ResourceId}, slot {SlotStart}",
+                booking.UserConfig.Username,
+                booking.UserConfig.ResourceId,
+                booking.Slot.StartTime);
+
             var bookResult = await _skeddaClient.BookAsync(booking, cancellationToken);
+            _logger.LogInformation("Skedda booking created with id {SkeddaBookingId}", bookResult.BookingId);
+
             var telegramResult = await _notificationSender.NotifyBookingSucceededAsync(booking.UserConfig, booking.Slot, cancellationToken);
+            _logger.LogInformation(
+                "Telegram success notification sent: chat {ChatId}, message {MessageId}",
+                telegramResult.ChatId,
+                telegramResult.MessageId);
+
             await _bookingCancellationLinkRepository.SaveAsync(
                 booking.UserConfig,
                 booking.Slot,
@@ -41,10 +64,16 @@ public sealed class ExecuteBookingUseCase
                 telegramResult.MessageId,
                 bookResult.BookingId,
                 cancellationToken);
+            _logger.LogInformation(
+                "Stored cancellation link: chat {ChatId}, message {MessageId}, booking {SkeddaBookingId}",
+                telegramResult.ChatId,
+                telegramResult.MessageId,
+                bookResult.BookingId);
         }
-        catch
+        catch (Exception ex)
         {
             _deduplicationStore.Release(bookingKey);
+            _logger.LogError(ex, "Booking execution failed for key {BookingKey}; dedup key released", bookingKey);
             throw;
         }
     }

--- a/src/TennisBooking.Application/TennisBooking.Application.csproj
+++ b/src/TennisBooking.Application/TennisBooking.Application.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../TennisBooking.Domain/TennisBooking.Domain.csproj" />
   </ItemGroup>
 </Project>

--- a/src/TennisBooking.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/TennisBooking.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -9,4 +9,14 @@ public class ApplicationDbContext : DbContext
         : base(options) { }
 
     public DbSet<UserConfig> UserConfigs { get; set; }
+    public DbSet<BookingCancellationLinkEntity> BookingCancellationLinks { get; set; }
+    public DbSet<TelegramPollingStateEntity> TelegramPollingStates { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<BookingCancellationLinkEntity>()
+            .HasIndex(x => new { x.ChatId, x.TelegramMessageId })
+            .IsUnique();
+    }
 }

--- a/src/TennisBooking.Infrastructure/Persistence/BookingCancellationLinkRepository.cs
+++ b/src/TennisBooking.Infrastructure/Persistence/BookingCancellationLinkRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using TennisBooking.Application.Abstractions;
 using TennisBooking.DAL;
 using TennisBooking.DAL.Models;
@@ -9,10 +10,12 @@ namespace TennisBooking.Infrastructure.Persistence;
 public sealed class BookingCancellationLinkRepository : IBookingCancellationLinkRepository
 {
     private readonly ApplicationDbContext _db;
+    private readonly ILogger<BookingCancellationLinkRepository> _logger;
 
-    public BookingCancellationLinkRepository(ApplicationDbContext db)
+    public BookingCancellationLinkRepository(ApplicationDbContext db, ILogger<BookingCancellationLinkRepository> logger)
     {
         _db = db;
+        _logger = logger;
     }
 
     public async Task SaveAsync(
@@ -43,6 +46,11 @@ public sealed class BookingCancellationLinkRepository : IBookingCancellationLink
 
         _db.BookingCancellationLinks.Add(entity);
         await _db.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation(
+            "Saved booking cancellation link: chat {ChatId}, message {MessageId}, booking {SkeddaBookingId}",
+            chatId,
+            telegramMessageId,
+            skeddaBookingId);
     }
 
     public async Task<BookingCancellationLink?> GetByReplyAsync(long chatId, int repliedTelegramMessageId, CancellationToken cancellationToken)
@@ -54,7 +62,19 @@ public sealed class BookingCancellationLinkRepository : IBookingCancellationLink
                 cancellationToken);
 
         if (entity is null)
+        {
+            _logger.LogInformation(
+                "No cancellation link found for chat {ChatId}, replied message {RepliedMessageId}",
+                chatId,
+                repliedTelegramMessageId);
             return null;
+        }
+
+        _logger.LogInformation(
+            "Found cancellation link for chat {ChatId}, replied message {RepliedMessageId}, booking {SkeddaBookingId}",
+            chatId,
+            repliedTelegramMessageId,
+            entity.SkeddaBookingId);
 
         var userConfig = new BookingUserConfig(
             entity.UserConfigId,
@@ -83,11 +103,22 @@ public sealed class BookingCancellationLinkRepository : IBookingCancellationLink
             cancellationToken);
 
         if (entity is null || entity.CancelledAtUtc.HasValue)
+        {
+            _logger.LogInformation(
+                "Cancellation mark skipped for chat {ChatId}, replied message {RepliedMessageId}: entity missing or already cancelled",
+                chatId,
+                repliedTelegramMessageId);
             return false;
+        }
 
         entity.CancelledAtUtc = DateTimeOffset.UtcNow;
         entity.CancelRequestMessageId = cancelRequestMessageId;
         await _db.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation(
+            "Marked cancellation link as cancelled: chat {ChatId}, replied message {RepliedMessageId}, cancel request message {CancelRequestMessageId}",
+            chatId,
+            repliedTelegramMessageId,
+            cancelRequestMessageId);
         return true;
     }
 }

--- a/src/TennisBooking.Infrastructure/Persistence/BookingCancellationLinkRepository.cs
+++ b/src/TennisBooking.Infrastructure/Persistence/BookingCancellationLinkRepository.cs
@@ -1,0 +1,93 @@
+using Microsoft.EntityFrameworkCore;
+using TennisBooking.Application.Abstractions;
+using TennisBooking.DAL;
+using TennisBooking.DAL.Models;
+using TennisBooking.Domain.Booking;
+
+namespace TennisBooking.Infrastructure.Persistence;
+
+public sealed class BookingCancellationLinkRepository : IBookingCancellationLinkRepository
+{
+    private readonly ApplicationDbContext _db;
+
+    public BookingCancellationLinkRepository(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task SaveAsync(
+        BookingUserConfig userConfig,
+        BookingSlot slot,
+        long chatId,
+        int telegramMessageId,
+        string skeddaBookingId,
+        CancellationToken cancellationToken)
+    {
+        var entity = new BookingCancellationLinkEntity
+        {
+            UserConfigId = userConfig.Id,
+            Username = userConfig.Username,
+            Password = userConfig.Password,
+            ResourceId = userConfig.ResourceId,
+            Venue = userConfig.Venue,
+            VenueUser = userConfig.VenueUser,
+            DayOfWeek = userConfig.DayOfWeek,
+            Hour = userConfig.Hour,
+            SlotStartUtc = slot.StartTime.ToUniversalTime(),
+            SlotEndUtc = slot.EndTime.ToUniversalTime(),
+            ChatId = chatId,
+            TelegramMessageId = telegramMessageId,
+            SkeddaBookingId = skeddaBookingId,
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        _db.BookingCancellationLinks.Add(entity);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<BookingCancellationLink?> GetByReplyAsync(long chatId, int repliedTelegramMessageId, CancellationToken cancellationToken)
+    {
+        var entity = await _db.BookingCancellationLinks
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                x => x.ChatId == chatId && x.TelegramMessageId == repliedTelegramMessageId,
+                cancellationToken);
+
+        if (entity is null)
+            return null;
+
+        var userConfig = new BookingUserConfig(
+            entity.UserConfigId,
+            entity.Username,
+            entity.Password,
+            entity.ResourceId,
+            entity.Venue,
+            entity.VenueUser,
+            entity.DayOfWeek,
+            entity.Hour);
+
+        return new BookingCancellationLink(
+            userConfig,
+            new BookingSlot(entity.SlotStartUtc),
+            entity.ChatId,
+            entity.TelegramMessageId,
+            entity.SkeddaBookingId,
+            entity.CreatedAtUtc,
+            entity.CancelledAtUtc);
+    }
+
+    public async Task<bool> TryMarkCancelledAsync(long chatId, int repliedTelegramMessageId, int cancelRequestMessageId, CancellationToken cancellationToken)
+    {
+        var entity = await _db.BookingCancellationLinks.FirstOrDefaultAsync(
+            x => x.ChatId == chatId && x.TelegramMessageId == repliedTelegramMessageId,
+            cancellationToken);
+
+        if (entity is null || entity.CancelledAtUtc.HasValue)
+            return false;
+
+        entity.CancelledAtUtc = DateTimeOffset.UtcNow;
+        entity.CancelRequestMessageId = cancelRequestMessageId;
+        await _db.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+}

--- a/src/TennisBooking.Infrastructure/Persistence/Models/BookingCancellationLinkEntity.cs
+++ b/src/TennisBooking.Infrastructure/Persistence/Models/BookingCancellationLinkEntity.cs
@@ -1,0 +1,22 @@
+namespace TennisBooking.DAL.Models;
+
+public class BookingCancellationLinkEntity
+{
+    public long Id { get; set; }
+    public int UserConfigId { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    public string ResourceId { get; set; } = string.Empty;
+    public string Venue { get; set; } = string.Empty;
+    public string VenueUser { get; set; } = string.Empty;
+    public DayOfWeek DayOfWeek { get; set; }
+    public int Hour { get; set; }
+    public DateTimeOffset SlotStartUtc { get; set; }
+    public DateTimeOffset SlotEndUtc { get; set; }
+    public long ChatId { get; set; }
+    public int TelegramMessageId { get; set; }
+    public string SkeddaBookingId { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAtUtc { get; set; }
+    public DateTimeOffset? CancelledAtUtc { get; set; }
+    public int? CancelRequestMessageId { get; set; }
+}

--- a/src/TennisBooking.Infrastructure/Persistence/Models/TelegramPollingStateEntity.cs
+++ b/src/TennisBooking.Infrastructure/Persistence/Models/TelegramPollingStateEntity.cs
@@ -1,0 +1,7 @@
+namespace TennisBooking.DAL.Models;
+
+public class TelegramPollingStateEntity
+{
+    public int Id { get; set; }
+    public long LastProcessedUpdateId { get; set; }
+}

--- a/src/TennisBooking.Infrastructure/Persistence/TelegramPollingStateRepository.cs
+++ b/src/TennisBooking.Infrastructure/Persistence/TelegramPollingStateRepository.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using TennisBooking.Application.Abstractions;
+using TennisBooking.DAL;
+using TennisBooking.DAL.Models;
+
+namespace TennisBooking.Infrastructure.Persistence;
+
+public sealed class TelegramPollingStateRepository : ITelegramPollingStateRepository
+{
+    private const int SingletonId = 1;
+    private readonly ApplicationDbContext _db;
+
+    public TelegramPollingStateRepository(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<long?> GetLastProcessedUpdateIdAsync(CancellationToken cancellationToken)
+    {
+        var state = await _db.TelegramPollingStates.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == SingletonId, cancellationToken);
+        return state?.LastProcessedUpdateId;
+    }
+
+    public async Task SaveLastProcessedUpdateIdAsync(long updateId, CancellationToken cancellationToken)
+    {
+        var state = await _db.TelegramPollingStates.FirstOrDefaultAsync(x => x.Id == SingletonId, cancellationToken);
+        if (state is null)
+        {
+            _db.TelegramPollingStates.Add(new TelegramPollingStateEntity
+            {
+                Id = SingletonId,
+                LastProcessedUpdateId = updateId
+            });
+        }
+        else
+        {
+            state.LastProcessedUpdateId = updateId;
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/TennisBooking.Infrastructure/Skedda/SkeddaClient.cs
+++ b/src/TennisBooking.Infrastructure/Skedda/SkeddaClient.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using TennisBooking.Application.Abstractions;
@@ -23,10 +24,12 @@ public sealed class SkeddaClient : ISkeddaClient
     private const string CsrfCookieName = "X-Skedda-RequestVerificationCookie";
 
     private readonly SkeddaOptions _options;
+    private readonly ILogger<SkeddaClient> _logger;
 
-    public SkeddaClient(IOptions<SkeddaOptions> options)
+    public SkeddaClient(IOptions<SkeddaOptions> options, ILogger<SkeddaClient> logger)
     {
         _options = options.Value;
+        _logger = logger;
     }
 
     public async Task<PreparedBooking> PrepareBookingAsync(
@@ -34,7 +37,12 @@ public sealed class SkeddaClient : ISkeddaClient
         BookingSlot slot,
         CancellationToken cancellationToken)
     {
+        _logger.LogInformation(
+            "Preparing Skedda booking session for user {Username}, slot {SlotStart}",
+            userConfig.Username,
+            slot.StartTime);
         var session = await CreateSessionAsync(userConfig, cancellationToken);
+        _logger.LogInformation("Prepared Skedda booking session for user {Username}", userConfig.Username);
         return new PreparedBooking(
             userConfig,
             slot,
@@ -46,6 +54,10 @@ public sealed class SkeddaClient : ISkeddaClient
 
     public async Task<SkeddaBookingResult> BookAsync(PreparedBooking booking, CancellationToken cancellationToken)
     {
+        _logger.LogInformation(
+            "Sending Skedda booking request for user {Username}, slot {SlotStart}",
+            booking.UserConfig.Username,
+            booking.Slot.StartTime);
         var baseUri = new Uri(_options.ApiBaseUrl);
         using var client = new HttpClient { BaseAddress = baseUri };
 
@@ -65,11 +77,16 @@ public sealed class SkeddaClient : ISkeddaClient
         if (string.IsNullOrWhiteSpace(bookingId))
             throw new InvalidOperationException("Skedda booking id was not found in response.");
 
+        _logger.LogInformation("Skedda booking succeeded with id {SkeddaBookingId}", bookingId);
         return new SkeddaBookingResult(bookingId);
     }
 
     public async Task CancelAsync(PreparedBooking booking, string bookingId, CancellationToken cancellationToken)
     {
+        _logger.LogInformation(
+            "Sending Skedda cancel request for booking {SkeddaBookingId}, user {Username}",
+            bookingId,
+            booking.UserConfig.Username);
         var session = await CreateSessionAsync(booking.UserConfig, cancellationToken);
 
         var baseUri = new Uri(_options.ApiBaseUrl);
@@ -82,10 +99,12 @@ public sealed class SkeddaClient : ISkeddaClient
         var deleteResp = await client.SendAsync(deleteReq, cancellationToken);
         if (!deleteResp.IsSuccessStatusCode)
             throw new HttpRequestException($"Response from Skedda {await deleteResp.Content.ReadAsStringAsync(cancellationToken)}");
+        _logger.LogInformation("Skedda cancellation succeeded for booking {SkeddaBookingId}", bookingId);
     }
 
     private async Task<SessionData> CreateSessionAsync(BookingUserConfig userConfig, CancellationToken cancellationToken)
     {
+        _logger.LogDebug("Creating authenticated Skedda session for user {Username}", userConfig.Username);
         var handler = new HttpClientHandler { CookieContainer = new CookieContainer() };
         var baseUri = new Uri(_options.ApiBaseUrl);
         using var client = new HttpClient(handler) { BaseAddress = baseUri };

--- a/src/TennisBooking.Infrastructure/Skedda/SkeddaClient.cs
+++ b/src/TennisBooking.Infrastructure/Skedda/SkeddaClient.cs
@@ -34,6 +34,58 @@ public sealed class SkeddaClient : ISkeddaClient
         BookingSlot slot,
         CancellationToken cancellationToken)
     {
+        var session = await CreateSessionAsync(userConfig, cancellationToken);
+        return new PreparedBooking(
+            userConfig,
+            slot,
+            BuildBookingBody(userConfig, slot),
+            session.RequestVerificationToken,
+            session.CsrfCookie,
+            session.ApplicationCookie);
+    }
+
+    public async Task<SkeddaBookingResult> BookAsync(PreparedBooking booking, CancellationToken cancellationToken)
+    {
+        var baseUri = new Uri(_options.ApiBaseUrl);
+        using var client = new HttpClient { BaseAddress = baseUri };
+
+        var bookReq = new HttpRequestMessage(HttpMethod.Post, BookingPath);
+        bookReq.Content = JsonContent(booking.Body);
+        bookReq.Headers.Add(CsrfHeaderName, booking.RequestVerificationToken);
+        bookReq.Headers.Add(CookieHeaderName,
+            $"{CsrfCookieName}={booking.CsrfCookie}; {ApplicationCookieName}={booking.ApplicationCookie}");
+
+        var bookResp = await client.SendAsync(bookReq, cancellationToken);
+        if (!bookResp.IsSuccessStatusCode)
+            throw new HttpRequestException($"Response from Skedda {await bookResp.Content.ReadAsStringAsync(cancellationToken)}");
+
+        var body = await bookResp.Content.ReadAsStringAsync(cancellationToken);
+        dynamic? json = JsonConvert.DeserializeObject(body);
+        var bookingId = (string?)json?.booking?.id;
+        if (string.IsNullOrWhiteSpace(bookingId))
+            throw new InvalidOperationException("Skedda booking id was not found in response.");
+
+        return new SkeddaBookingResult(bookingId);
+    }
+
+    public async Task CancelAsync(PreparedBooking booking, string bookingId, CancellationToken cancellationToken)
+    {
+        var session = await CreateSessionAsync(booking.UserConfig, cancellationToken);
+
+        var baseUri = new Uri(_options.ApiBaseUrl);
+        using var client = new HttpClient { BaseAddress = baseUri };
+        var deleteReq = new HttpRequestMessage(HttpMethod.Delete, $"{BookingPath}/{bookingId}");
+        deleteReq.Headers.Add(CsrfHeaderName, session.RequestVerificationToken);
+        deleteReq.Headers.Add(CookieHeaderName,
+            $"{CsrfCookieName}={session.CsrfCookie}; {ApplicationCookieName}={session.ApplicationCookie}");
+
+        var deleteResp = await client.SendAsync(deleteReq, cancellationToken);
+        if (!deleteResp.IsSuccessStatusCode)
+            throw new HttpRequestException($"Response from Skedda {await deleteResp.Content.ReadAsStringAsync(cancellationToken)}");
+    }
+
+    private async Task<SessionData> CreateSessionAsync(BookingUserConfig userConfig, CancellationToken cancellationToken)
+    {
         var handler = new HttpClientHandler { CookieContainer = new CookieContainer() };
         var baseUri = new Uri(_options.ApiBaseUrl);
         using var client = new HttpClient(handler) { BaseAddress = baseUri };
@@ -74,32 +126,7 @@ public sealed class SkeddaClient : ISkeddaClient
         getBookingsResp.EnsureSuccessStatusCode();
         requestVerificationToken = GetRequestVerificationToken(
             await getBookingsResp.Content.ReadAsStringAsync(cancellationToken));
-
-        return new PreparedBooking(
-            userConfig,
-            slot,
-            BuildBookingBody(userConfig, slot),
-            requestVerificationToken,
-            csrfCookie,
-            applicationCookie);
-    }
-
-    public async Task BookAsync(PreparedBooking booking, CancellationToken cancellationToken)
-    {
-        var baseUri = new Uri(_options.ApiBaseUrl);
-        using var client = new HttpClient { BaseAddress = baseUri };
-
-        var bookReq = new HttpRequestMessage(HttpMethod.Post, BookingPath);
-        bookReq.Content = JsonContent(booking.Body);
-        bookReq.Headers.Add(CsrfHeaderName, booking.RequestVerificationToken);
-        bookReq.Headers.Add(CookieHeaderName,
-            $"{CsrfCookieName}={booking.CsrfCookie}; {ApplicationCookieName}={booking.ApplicationCookie}");
-
-        var bookResp = await client.SendAsync(bookReq, cancellationToken);
-        if (!bookResp.IsSuccessStatusCode)
-            throw new HttpRequestException($"Response from Skedda {await bookResp.Content.ReadAsStringAsync(cancellationToken)}");
-
-        bookResp.EnsureSuccessStatusCode();
+        return new SessionData(requestVerificationToken, csrfCookie, applicationCookie);
     }
 
     private static StringContent JsonContent(object value)
@@ -153,4 +180,6 @@ public sealed class SkeddaClient : ISkeddaClient
 
         return match.Groups[1].Value;
     }
+
+    private sealed record SessionData(string RequestVerificationToken, string CsrfCookie, string ApplicationCookie);
 }

--- a/src/TennisBooking.Infrastructure/Telegram/TelegramLongPollingService.cs
+++ b/src/TennisBooking.Infrastructure/Telegram/TelegramLongPollingService.cs
@@ -1,0 +1,181 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TennisBooking.Application.Abstractions;
+using TennisBooking.Application.Booking;
+using TennisBooking.Options;
+
+namespace TennisBooking.Infrastructure.Telegram;
+
+public sealed class TelegramLongPollingService : BackgroundService
+{
+    private const string BaseUrlPrefix = "https://api.telegram.org/bot";
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly TelegramOptions _options;
+    private readonly ILogger<TelegramLongPollingService> _logger;
+
+    public TelegramLongPollingService(
+        IServiceScopeFactory scopeFactory,
+        IHttpClientFactory httpClientFactory,
+        IOptions<TelegramOptions> options,
+        ILogger<TelegramLongPollingService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _httpClientFactory = httpClientFactory;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (string.IsNullOrWhiteSpace(_options.BotToken))
+            return;
+
+        var offset = await LoadOffsetAsync(stoppingToken);
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var updates = await GetUpdatesAsync(offset, stoppingToken);
+                foreach (var update in updates)
+                {
+                    offset = Math.Max(offset, update.UpdateId + 1);
+                    await ProcessUpdateAsync(update, stoppingToken);
+                    await SaveOffsetAsync(update.UpdateId, stoppingToken);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Telegram polling iteration failed");
+                await Task.Delay(TimeSpan.FromSeconds(3), stoppingToken);
+            }
+        }
+    }
+
+    private async Task<long> LoadOffsetAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stateRepo = scope.ServiceProvider.GetRequiredService<ITelegramPollingStateRepository>();
+        var lastProcessed = await stateRepo.GetLastProcessedUpdateIdAsync(cancellationToken);
+        return lastProcessed.HasValue ? lastProcessed.Value + 1 : 0;
+    }
+
+    private async Task SaveOffsetAsync(long updateId, CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stateRepo = scope.ServiceProvider.GetRequiredService<ITelegramPollingStateRepository>();
+        await stateRepo.SaveLastProcessedUpdateIdAsync(updateId, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<TelegramUpdate>> GetUpdatesAsync(long offset, CancellationToken cancellationToken)
+    {
+        var http = _httpClientFactory.CreateClient();
+        var url = $"{BaseUrlPrefix}{_options.BotToken}/getUpdates";
+        var payload = new { offset, timeout = 40, allowed_updates = new[] { "message" } };
+        var req = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+        var resp = await http.PostAsync(url, req, cancellationToken);
+        resp.EnsureSuccessStatusCode();
+        var json = await resp.Content.ReadAsStringAsync(cancellationToken);
+        var envelope = JsonSerializer.Deserialize<TelegramUpdatesResponse>(json) ?? new TelegramUpdatesResponse();
+        return envelope.Result ?? [];
+    }
+
+    private async Task ProcessUpdateAsync(TelegramUpdate update, CancellationToken cancellationToken)
+    {
+        var message = update.Message;
+        if (message?.Chat?.Id != _options.ChatId || string.IsNullOrWhiteSpace(message.Text))
+            return;
+
+        if (!string.Equals(message.Text.Trim(), "/cancel", StringComparison.Ordinal))
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var links = scope.ServiceProvider.GetRequiredService<IBookingCancellationLinkRepository>();
+        var notification = scope.ServiceProvider.GetRequiredService<INotificationSender>();
+        var skedda = scope.ServiceProvider.GetRequiredService<ISkeddaClient>();
+
+        var repliedMessageId = message.ReplyToMessage?.MessageId;
+        if (!repliedMessageId.HasValue)
+        {
+            await notification.NotifyMessageAsync("Use /cancel as a reply to the booking confirmation message.", cancellationToken);
+            return;
+        }
+
+        var link = await links.GetByReplyAsync(message.Chat.Id, repliedMessageId.Value, cancellationToken);
+        if (link is null)
+        {
+            await notification.NotifyMessageAsync("I couldn't find a booking for that message.", cancellationToken);
+            return;
+        }
+
+        if (link.CancelledAtUtc.HasValue)
+        {
+            await notification.NotifyMessageAsync("This booking is already cancelled.", cancellationToken);
+            return;
+        }
+
+        var prepared = new PreparedBooking(
+            link.UserConfig,
+            link.Slot,
+            new { },
+            string.Empty,
+            string.Empty,
+            string.Empty);
+        await skedda.CancelAsync(prepared, link.SkeddaBookingId, cancellationToken);
+        var marked = await links.TryMarkCancelledAsync(message.Chat.Id, repliedMessageId.Value, message.MessageId, cancellationToken);
+        if (!marked)
+        {
+            await notification.NotifyMessageAsync("This booking is already cancelled.", cancellationToken);
+            return;
+        }
+
+        await notification.NotifyMessageAsync($"Cancelled booking {link.SkeddaBookingId}.", cancellationToken);
+    }
+
+    private sealed class TelegramUpdatesResponse
+    {
+        [JsonPropertyName("result")]
+        public List<TelegramUpdate>? Result { get; set; }
+    }
+
+    private sealed class TelegramUpdate
+    {
+        [JsonPropertyName("update_id")]
+        public long UpdateId { get; set; }
+        [JsonPropertyName("message")]
+        public TelegramMessage? Message { get; set; }
+    }
+
+    private sealed class TelegramMessage
+    {
+        [JsonPropertyName("message_id")]
+        public int MessageId { get; set; }
+        [JsonPropertyName("chat")]
+        public TelegramChat? Chat { get; set; }
+        [JsonPropertyName("text")]
+        public string? Text { get; set; }
+        [JsonPropertyName("reply_to_message")]
+        public TelegramReplyMessage? ReplyToMessage { get; set; }
+    }
+
+    private sealed class TelegramReplyMessage
+    {
+        [JsonPropertyName("message_id")]
+        public int MessageId { get; set; }
+    }
+
+    private sealed class TelegramChat
+    {
+        [JsonPropertyName("id")]
+        public long Id { get; set; }
+    }
+}

--- a/src/TennisBooking.Infrastructure/Telegram/TelegramLongPollingService.cs
+++ b/src/TennisBooking.Infrastructure/Telegram/TelegramLongPollingService.cs
@@ -34,14 +34,20 @@ public sealed class TelegramLongPollingService : BackgroundService
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         if (string.IsNullOrWhiteSpace(_options.BotToken))
+        {
+            _logger.LogWarning("Telegram long polling is disabled because BotToken is empty");
             return;
+        }
 
         var offset = await LoadOffsetAsync(stoppingToken);
+        _logger.LogInformation("Telegram long polling started with offset {Offset}", offset);
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
                 var updates = await GetUpdatesAsync(offset, stoppingToken);
+                if (updates.Count > 0)
+                    _logger.LogInformation("Received {Count} Telegram updates starting from offset {Offset}", updates.Count, offset);
                 foreach (var update in updates)
                 {
                     offset = Math.Max(offset, update.UpdateId + 1);
@@ -51,6 +57,7 @@ public sealed class TelegramLongPollingService : BackgroundService
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
+                _logger.LogInformation("Telegram long polling stopped by cancellation");
                 return;
             }
             catch (Exception ex)
@@ -66,7 +73,9 @@ public sealed class TelegramLongPollingService : BackgroundService
         using var scope = _scopeFactory.CreateScope();
         var stateRepo = scope.ServiceProvider.GetRequiredService<ITelegramPollingStateRepository>();
         var lastProcessed = await stateRepo.GetLastProcessedUpdateIdAsync(cancellationToken);
-        return lastProcessed.HasValue ? lastProcessed.Value + 1 : 0;
+        var offset = lastProcessed.HasValue ? lastProcessed.Value + 1 : 0;
+        _logger.LogInformation("Loaded Telegram polling offset {Offset}", offset);
+        return offset;
     }
 
     private async Task SaveOffsetAsync(long updateId, CancellationToken cancellationToken)
@@ -74,6 +83,7 @@ public sealed class TelegramLongPollingService : BackgroundService
         using var scope = _scopeFactory.CreateScope();
         var stateRepo = scope.ServiceProvider.GetRequiredService<ITelegramPollingStateRepository>();
         await stateRepo.SaveLastProcessedUpdateIdAsync(updateId, cancellationToken);
+        _logger.LogDebug("Saved Telegram polling offset for update {UpdateId}", updateId);
     }
 
     private async Task<IReadOnlyList<TelegramUpdate>> GetUpdatesAsync(long offset, CancellationToken cancellationToken)
@@ -93,10 +103,22 @@ public sealed class TelegramLongPollingService : BackgroundService
     {
         var message = update.Message;
         if (message?.Chat?.Id != _options.ChatId || string.IsNullOrWhiteSpace(message.Text))
+        {
+            _logger.LogDebug("Ignoring Telegram update {UpdateId}: no text or unexpected chat", update.UpdateId);
             return;
+        }
 
         if (!string.Equals(message.Text.Trim(), "/cancel", StringComparison.Ordinal))
+        {
+            _logger.LogDebug("Ignoring Telegram message {MessageId}: unsupported command text '{Text}'", message.MessageId, message.Text);
             return;
+        }
+
+        _logger.LogInformation(
+            "Processing /cancel command from chat {ChatId}, message {MessageId}, replyTo {ReplyToMessageId}",
+            message.Chat.Id,
+            message.MessageId,
+            message.ReplyToMessage?.MessageId);
 
         using var scope = _scopeFactory.CreateScope();
         var links = scope.ServiceProvider.GetRequiredService<IBookingCancellationLinkRepository>();
@@ -106,20 +128,28 @@ public sealed class TelegramLongPollingService : BackgroundService
         var repliedMessageId = message.ReplyToMessage?.MessageId;
         if (!repliedMessageId.HasValue)
         {
-            await notification.NotifyMessageAsync("Use /cancel as a reply to the booking confirmation message.", cancellationToken);
+            _logger.LogInformation("Rejecting /cancel message {MessageId}: not sent as reply", message.MessageId);
+            await notification.NotifyMessageAsync("Використай /cancel як відповідь на повідомлення про бронювання.", cancellationToken);
             return;
         }
 
         var link = await links.GetByReplyAsync(message.Chat.Id, repliedMessageId.Value, cancellationToken);
         if (link is null)
         {
-            await notification.NotifyMessageAsync("I couldn't find a booking for that message.", cancellationToken);
+            _logger.LogInformation(
+                "Rejecting /cancel message {MessageId}: no booking link for replied message {RepliedMessageId}",
+                message.MessageId,
+                repliedMessageId.Value);
+            await notification.NotifyMessageAsync("Не знайшов бронювання для цього повідомлення.", cancellationToken);
             return;
         }
 
         if (link.CancelledAtUtc.HasValue)
         {
-            await notification.NotifyMessageAsync("This booking is already cancelled.", cancellationToken);
+            _logger.LogInformation(
+                "Skipping /cancel for booking {SkeddaBookingId}: already cancelled",
+                link.SkeddaBookingId);
+            await notification.NotifyMessageAsync("Це бронювання вже скасовано.", cancellationToken);
             return;
         }
 
@@ -134,11 +164,15 @@ public sealed class TelegramLongPollingService : BackgroundService
         var marked = await links.TryMarkCancelledAsync(message.Chat.Id, repliedMessageId.Value, message.MessageId, cancellationToken);
         if (!marked)
         {
-            await notification.NotifyMessageAsync("This booking is already cancelled.", cancellationToken);
+            _logger.LogInformation(
+                "Cancellation race detected for booking {SkeddaBookingId}: already cancelled by another request",
+                link.SkeddaBookingId);
+            await notification.NotifyMessageAsync("Це бронювання вже скасовано.", cancellationToken);
             return;
         }
 
-        await notification.NotifyMessageAsync($"Cancelled booking {link.SkeddaBookingId}.", cancellationToken);
+        _logger.LogInformation("Cancellation completed for booking {SkeddaBookingId}", link.SkeddaBookingId);
+        await notification.NotifyMessageAsync($"Скасував бронювання {link.SkeddaBookingId}.", cancellationToken);
     }
 
     private sealed class TelegramUpdatesResponse

--- a/src/TennisBooking.Infrastructure/Telegram/TelegramNotificationSender.cs
+++ b/src/TennisBooking.Infrastructure/Telegram/TelegramNotificationSender.cs
@@ -27,7 +27,7 @@ public sealed class TelegramNotificationSender : INotificationSender
         _logger = logger;
     }
 
-    public async Task NotifyBookingSucceededAsync(
+    public async Task<TelegramNotificationResult> NotifyBookingSucceededAsync(
         BookingUserConfig userConfig,
         BookingSlot slot,
         CancellationToken cancellationToken)
@@ -40,19 +40,42 @@ public sealed class TelegramNotificationSender : INotificationSender
 
         try
         {
-            var url = $"{BaseUrlPrefix}{_options.BotToken}/sendMessage";
-            var payload = new { chat_id = _options.ChatId, text = message, parse_mode = "MarkdownV2" };
-            var content = new StringContent(
-                JsonSerializer.Serialize(payload),
-                Encoding.UTF8,
-                "application/json");
-
-            var resp = await _http.PostAsync(url, content, cancellationToken);
-            resp.EnsureSuccessStatusCode();
+            return await SendMessageInternalAsync(message, "MarkdownV2", cancellationToken);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to send Telegram notification");
+            return new TelegramNotificationResult(_options.ChatId, 0);
         }
+    }
+
+    public async Task NotifyMessageAsync(string message, CancellationToken cancellationToken)
+        => await SendMessageInternalAsync(message, null, cancellationToken);
+
+    private async Task<TelegramNotificationResult> SendMessageInternalAsync(
+        string message,
+        string? parseMode,
+        CancellationToken cancellationToken)
+    {
+        var url = $"{BaseUrlPrefix}{_options.BotToken}/sendMessage";
+        var payload = new Dictionary<string, object?>
+        {
+            ["chat_id"] = _options.ChatId,
+            ["text"] = message
+        };
+        if (!string.IsNullOrWhiteSpace(parseMode))
+            payload["parse_mode"] = parseMode;
+
+        var content = new StringContent(
+            JsonSerializer.Serialize(payload),
+            Encoding.UTF8);
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+
+        var resp = await _http.PostAsync(url, content, cancellationToken);
+        resp.EnsureSuccessStatusCode();
+        var json = await resp.Content.ReadAsStringAsync(cancellationToken);
+        using var doc = JsonDocument.Parse(json);
+        var messageId = doc.RootElement.GetProperty("result").GetProperty("message_id").GetInt32();
+        return new TelegramNotificationResult(_options.ChatId, messageId);
     }
 }

--- a/src/TennisBooking.Infrastructure/TennisBooking.Infrastructure.csproj
+++ b/src/TennisBooking.Infrastructure/TennisBooking.Infrastructure.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/src/TennisBooking/Migrations/20260522133922_AddTelegramCancellationFlow.Designer.cs
+++ b/src/TennisBooking/Migrations/20260522133922_AddTelegramCancellationFlow.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TennisBooking.DAL;
@@ -11,9 +12,11 @@ using TennisBooking.DAL;
 namespace TennisBooking.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260522133922_AddTelegramCancellationFlow")]
+    partial class AddTelegramCancellationFlow
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TennisBooking/Migrations/20260522133922_AddTelegramCancellationFlow.cs
+++ b/src/TennisBooking/Migrations/20260522133922_AddTelegramCancellationFlow.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace TennisBooking.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTelegramCancellationFlow : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "BookingCancellationLinks",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserConfigId = table.Column<int>(type: "integer", nullable: false),
+                    Username = table.Column<string>(type: "text", nullable: false),
+                    Password = table.Column<string>(type: "text", nullable: false),
+                    ResourceId = table.Column<string>(type: "text", nullable: false),
+                    Venue = table.Column<string>(type: "text", nullable: false),
+                    VenueUser = table.Column<string>(type: "text", nullable: false),
+                    DayOfWeek = table.Column<int>(type: "integer", nullable: false),
+                    Hour = table.Column<int>(type: "integer", nullable: false),
+                    SlotStartUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    SlotEndUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ChatId = table.Column<long>(type: "bigint", nullable: false),
+                    TelegramMessageId = table.Column<int>(type: "integer", nullable: false),
+                    SkeddaBookingId = table.Column<string>(type: "text", nullable: false),
+                    CreatedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CancelledAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CancelRequestMessageId = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BookingCancellationLinks", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TelegramPollingStates",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    LastProcessedUpdateId = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TelegramPollingStates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BookingCancellationLinks_ChatId_TelegramMessageId",
+                table: "BookingCancellationLinks",
+                columns: new[] { "ChatId", "TelegramMessageId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BookingCancellationLinks");
+
+            migrationBuilder.DropTable(
+                name: "TelegramPollingStates");
+        }
+    }
+}

--- a/src/TennisBooking/Program.cs
+++ b/src/TennisBooking/Program.cs
@@ -53,8 +53,11 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<PreciseBookingSche
 builder.Services.AddSingleton<IClock, SystemClock>();
 builder.Services.AddSingleton<IBookingDeduplicationStore, InMemoryBookingDeduplicationStore>();
 builder.Services.AddScoped<IUserBookingConfigRepository, UserBookingConfigRepository>();
+builder.Services.AddScoped<IBookingCancellationLinkRepository, BookingCancellationLinkRepository>();
+builder.Services.AddScoped<ITelegramPollingStateRepository, TelegramPollingStateRepository>();
 builder.Services.AddScoped<ISkeddaClient, SkeddaClient>();
 builder.Services.AddScoped<INotificationSender, TelegramNotificationSender>();
+builder.Services.AddHostedService<TelegramLongPollingService>();
 builder.Services.AddScoped<IBookingScheduler, HangfireBookingScheduler>();
 builder.Services.AddScoped<PrepareBookingUseCase>();
 builder.Services.AddScoped<PrepareBookingForConfigUseCase>();

--- a/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
+++ b/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
@@ -80,7 +80,7 @@ public sealed class BookingPostgresIntegrationTests
         {
             bookingPosts++;
             ctx.Response.StatusCode = 200;
-            return "{}";
+            return """{"booking":{"id":"1"}}""";
         });
 
         var userConfig = NewConfig("postgres-fallback");
@@ -88,10 +88,14 @@ public sealed class BookingPostgresIntegrationTests
         await db.SaveChangesAsync();
 
         var skeddaClient = new SkeddaClient(Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }));
+        var notification = new Mock<INotificationSender>();
+        notification.Setup(x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TelegramNotificationResult(5, 10));
         var execute = new ExecuteBookingUseCase(
             skeddaClient,
-            Mock.Of<INotificationSender>(),
-            new InMemoryBookingDeduplicationStore());
+            notification.Object,
+            new InMemoryBookingDeduplicationStore(),
+            new BookingCancellationLinkRepository(db));
         var fallback = new BookingFallbackUseCase(new UserBookingConfigRepository(db), skeddaClient, execute);
         var startTime = new DateTimeOffset(2030, 1, 1, userConfig.Hour, 0, 0, TimeSpan.Zero);
 
@@ -114,7 +118,7 @@ public sealed class BookingPostgresIntegrationTests
         {
             bookingPosts++;
             ctx.Response.StatusCode = 200;
-            return "{}";
+            return """{"booking":{"id":"1"}}""";
         });
         EnqueuePreparationResponses(skedda);
 
@@ -122,9 +126,16 @@ public sealed class BookingPostgresIntegrationTests
         db.UserConfigs.Add(userConfig);
         await db.SaveChangesAsync();
 
+        var notification = new Mock<INotificationSender>();
+        notification.Setup(x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TelegramNotificationResult(5, 10));
         var skeddaClient = new SkeddaClient(Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }));
         var dedupe = new InMemoryBookingDeduplicationStore();
-        var execute = new ExecuteBookingUseCase(skeddaClient, Mock.Of<INotificationSender>(), dedupe);
+        var execute = new ExecuteBookingUseCase(
+            skeddaClient,
+            notification.Object,
+            dedupe,
+            new BookingCancellationLinkRepository(db));
         var fallback = new BookingFallbackUseCase(new UserBookingConfigRepository(db), skeddaClient, execute);
         var startTime = new DateTimeOffset(2030, 1, 1, userConfig.Hour, 0, 0, TimeSpan.Zero);
 

--- a/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
+++ b/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
@@ -42,7 +42,9 @@ public sealed class BookingPostgresIntegrationTests
         var backgroundJobs = new BackgroundJobClient(storage);
         var scheduler = new HangfireBookingScheduler(backgroundJobs, Mock.Of<IPreciseBookingScheduler>());
         var service = new PrepareBookingUseCase(
-            new SkeddaClient(Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl })),
+            new SkeddaClient(
+                Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }),
+                NullLogger<SkeddaClient>.Instance),
             scheduler,
             new FixedClock(new DateTimeOffset(2026, 5, 19, 12, 0, 0, TimeSpan.Zero)));
 
@@ -87,7 +89,9 @@ public sealed class BookingPostgresIntegrationTests
         db.UserConfigs.Add(userConfig);
         await db.SaveChangesAsync();
 
-        var skeddaClient = new SkeddaClient(Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }));
+        var skeddaClient = new SkeddaClient(
+            Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }),
+            NullLogger<SkeddaClient>.Instance);
         var notification = new Mock<INotificationSender>();
         notification.Setup(x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new TelegramNotificationResult(5, 10));
@@ -95,7 +99,8 @@ public sealed class BookingPostgresIntegrationTests
             skeddaClient,
             notification.Object,
             new InMemoryBookingDeduplicationStore(),
-            new BookingCancellationLinkRepository(db));
+            new BookingCancellationLinkRepository(db, NullLogger<BookingCancellationLinkRepository>.Instance),
+            NullLogger<ExecuteBookingUseCase>.Instance);
         var fallback = new BookingFallbackUseCase(new UserBookingConfigRepository(db), skeddaClient, execute);
         var startTime = new DateTimeOffset(2030, 1, 1, userConfig.Hour, 0, 0, TimeSpan.Zero);
 
@@ -129,13 +134,16 @@ public sealed class BookingPostgresIntegrationTests
         var notification = new Mock<INotificationSender>();
         notification.Setup(x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new TelegramNotificationResult(5, 10));
-        var skeddaClient = new SkeddaClient(Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }));
+        var skeddaClient = new SkeddaClient(
+            Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }),
+            NullLogger<SkeddaClient>.Instance);
         var dedupe = new InMemoryBookingDeduplicationStore();
         var execute = new ExecuteBookingUseCase(
             skeddaClient,
             notification.Object,
             dedupe,
-            new BookingCancellationLinkRepository(db));
+            new BookingCancellationLinkRepository(db, NullLogger<BookingCancellationLinkRepository>.Instance),
+            NullLogger<ExecuteBookingUseCase>.Instance);
         var fallback = new BookingFallbackUseCase(new UserBookingConfigRepository(db), skeddaClient, execute);
         var startTime = new DateTimeOffset(2030, 1, 1, userConfig.Hour, 0, 0, TimeSpan.Zero);
 

--- a/tests/TennisBooking.Tests/UnitTests.cs
+++ b/tests/TennisBooking.Tests/UnitTests.cs
@@ -66,11 +66,16 @@ public class UnitTests
     public async Task ExecuteBooking_DoesNotPostTwice_ForSameSlot()
     {
         var skedda = new Mock<ISkeddaClient>();
+        skedda.Setup(x => x.BookAsync(It.IsAny<PreparedBooking>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SkeddaBookingResult("1"));
         var notification = new Mock<INotificationSender>();
+        notification.Setup(x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TelegramNotificationResult(5, 10));
         var useCase = new ExecuteBookingUseCase(
             skedda.Object,
             notification.Object,
-            new InMemoryBookingDeduplicationStore());
+            new InMemoryBookingDeduplicationStore(),
+            Mock.Of<IBookingCancellationLinkRepository>());
         var booking = Prepared(BasicDomainConfig(), new BookingSlot(new DateTimeOffset(2030, 6, 15, 10, 0, 0, TimeSpan.Zero)));
 
         await useCase.ExecuteAsync(booking, CancellationToken.None);
@@ -89,10 +94,19 @@ public class UnitTests
         await db.SaveChangesAsync();
 
         var skedda = new Mock<ISkeddaClient>();
+        skedda.Setup(x => x.BookAsync(It.IsAny<PreparedBooking>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SkeddaBookingResult("1"));
+        var notification = new Mock<INotificationSender>();
+        notification.Setup(x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TelegramNotificationResult(5, 10));
         var prepared = Prepared(ToDomain(entity), new BookingSlot(new DateTimeOffset(2030, 1, 1, entity.Hour, 0, 0, TimeSpan.Zero)));
         skedda.Setup(x => x.PrepareBookingAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(prepared);
-        var execute = new ExecuteBookingUseCase(skedda.Object, Mock.Of<INotificationSender>(), new InMemoryBookingDeduplicationStore());
+        var execute = new ExecuteBookingUseCase(
+            skedda.Object,
+            notification.Object,
+            new InMemoryBookingDeduplicationStore(),
+            Mock.Of<IBookingCancellationLinkRepository>());
         var fallback = new BookingFallbackUseCase(new UserBookingConfigRepository(db), skedda.Object, execute);
 
         await fallback.ExecuteAsync(entity.Id, prepared.Slot.StartTime, CancellationToken.None);
@@ -107,7 +121,11 @@ public class UnitTests
         var fallback = new BookingFallbackUseCase(
             new UserBookingConfigRepository(db),
             Mock.Of<ISkeddaClient>(),
-            new ExecuteBookingUseCase(Mock.Of<ISkeddaClient>(), Mock.Of<INotificationSender>(), new InMemoryBookingDeduplicationStore()));
+            new ExecuteBookingUseCase(
+                Mock.Of<ISkeddaClient>(),
+                Mock.Of<INotificationSender>(),
+                new InMemoryBookingDeduplicationStore(),
+                Mock.Of<IBookingCancellationLinkRepository>()));
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             fallback.ExecuteAsync(999, DateTimeOffset.UtcNow, CancellationToken.None));
@@ -138,7 +156,7 @@ public class UnitTests
         {
             bookingPosts++;
             ctx.Response.StatusCode = 200;
-            return "{}";
+            return """{"booking":{"id":"1"}}""";
         });
         var client = new SkeddaClient(Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }));
         var booking = Prepared(BasicDomainConfig(), new BookingSlot(DateTimeOffset.UtcNow));
@@ -151,7 +169,16 @@ public class UnitTests
     [Fact]
     public async Task TelegramNotificationSender_Notify_Works_And_HandlesMissingConfig()
     {
-        var handler = new DelegateHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        var handler = new DelegateHandler((req, _) =>
+        {
+            var body = req.RequestUri!.AbsoluteUri.Contains("sendMessage", StringComparison.Ordinal)
+                ? """{"ok":true,"result":{"message_id":123}}"""
+                : "{}";
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        });
 
         var sender = new TelegramNotificationSender(
             new HttpClient(handler),

--- a/tests/TennisBooking.Tests/UnitTests.cs
+++ b/tests/TennisBooking.Tests/UnitTests.cs
@@ -5,6 +5,7 @@ using Hangfire.Dashboard;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -75,7 +76,8 @@ public class UnitTests
             skedda.Object,
             notification.Object,
             new InMemoryBookingDeduplicationStore(),
-            Mock.Of<IBookingCancellationLinkRepository>());
+            Mock.Of<IBookingCancellationLinkRepository>(),
+            NullLogger<ExecuteBookingUseCase>.Instance);
         var booking = Prepared(BasicDomainConfig(), new BookingSlot(new DateTimeOffset(2030, 6, 15, 10, 0, 0, TimeSpan.Zero)));
 
         await useCase.ExecuteAsync(booking, CancellationToken.None);
@@ -106,7 +108,8 @@ public class UnitTests
             skedda.Object,
             notification.Object,
             new InMemoryBookingDeduplicationStore(),
-            Mock.Of<IBookingCancellationLinkRepository>());
+            Mock.Of<IBookingCancellationLinkRepository>(),
+            NullLogger<ExecuteBookingUseCase>.Instance);
         var fallback = new BookingFallbackUseCase(new UserBookingConfigRepository(db), skedda.Object, execute);
 
         await fallback.ExecuteAsync(entity.Id, prepared.Slot.StartTime, CancellationToken.None);
@@ -125,7 +128,8 @@ public class UnitTests
                 Mock.Of<ISkeddaClient>(),
                 Mock.Of<INotificationSender>(),
                 new InMemoryBookingDeduplicationStore(),
-                Mock.Of<IBookingCancellationLinkRepository>()));
+                Mock.Of<IBookingCancellationLinkRepository>(),
+                NullLogger<ExecuteBookingUseCase>.Instance));
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             fallback.ExecuteAsync(999, DateTimeOffset.UtcNow, CancellationToken.None));
@@ -141,7 +145,9 @@ public class UnitTests
             return "<html>no token</html>";
         });
 
-        var client = new SkeddaClient(Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = server.BaseUrl }));
+        var client = new SkeddaClient(
+            Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = server.BaseUrl }),
+            NullLogger<SkeddaClient>.Instance);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             client.PrepareBookingAsync(BasicDomainConfig(), new BookingSlot(DateTimeOffset.UtcNow), CancellationToken.None));
@@ -158,7 +164,9 @@ public class UnitTests
             ctx.Response.StatusCode = 200;
             return """{"booking":{"id":"1"}}""";
         });
-        var client = new SkeddaClient(Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }));
+        var client = new SkeddaClient(
+            Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }),
+            NullLogger<SkeddaClient>.Instance);
         var booking = Prepared(BasicDomainConfig(), new BookingSlot(DateTimeOffset.UtcNow));
 
         await client.BookAsync(booking, CancellationToken.None);


### PR DESCRIPTION
## Summary
- add Telegram long-polling background service using getUpdates
- support /cancel only when replying to booking-success bot message
- capture Skedda booking ID from booking response and persist message-to-booking links
- add Skedda cancellation call (DELETE /bookings/{id}) and idempotent cancellation tracking
- persist Telegram polling offset for restart safety
- add EF migration for cancellation link and polling state tables

## Testing
- dotnet test tests/TennisBooking.Tests/TennisBooking.Tests.csproj -v minimal