### PR TITLE
Add attendance reaction reminders and clarify cancellation flow

### DIFF
--- a/src/TennisBooking.Application/Abstractions/BookingCancellationLink.cs
+++ b/src/TennisBooking.Application/Abstractions/BookingCancellationLink.cs
@@ -9,4 +9,6 @@ public sealed record BookingCancellationLink(
     int TelegramMessageId,
     string SkeddaBookingId,
     DateTimeOffset CreatedAtUtc,
-    DateTimeOffset? CancelledAtUtc);
+    DateTimeOffset? CancelledAtUtc,
+    DateTimeOffset? AttendanceReminder24hSentAtUtc,
+    DateTimeOffset? AttendanceReminder2hSentAtUtc);

--- a/src/TennisBooking.Application/Abstractions/IBookingCancellationLinkRepository.cs
+++ b/src/TennisBooking.Application/Abstractions/IBookingCancellationLinkRepository.cs
@@ -13,6 +13,8 @@ public interface IBookingCancellationLinkRepository
         CancellationToken cancellationToken);
 
     Task<BookingCancellationLink?> GetByReplyAsync(long chatId, int repliedTelegramMessageId, CancellationToken cancellationToken);
+    Task<BookingCancellationLink?> GetByMessageAsync(long chatId, int telegramMessageId, CancellationToken cancellationToken);
 
     Task<bool> TryMarkCancelledAsync(long chatId, int repliedTelegramMessageId, int cancelRequestMessageId, CancellationToken cancellationToken);
+    Task<bool> TryMarkReminderSentAsync(long chatId, int telegramMessageId, string reminderType, CancellationToken cancellationToken);
 }

--- a/src/TennisBooking.Application/Abstractions/IBookingScheduler.cs
+++ b/src/TennisBooking.Application/Abstractions/IBookingScheduler.cs
@@ -7,5 +7,6 @@ public interface IBookingScheduler
 {
     void SchedulePreciseBooking(PreparedBooking booking);
     void ScheduleFallback(int userConfigId, DateTimeOffset startTime, DateTimeOffset runAt);
+    void ScheduleAttendanceCheck(long chatId, int telegramMessageId, DateTimeOffset slotStartUtc, string reminderType, DateTimeOffset runAtUtc);
     void ScheduleRecurringPreparation(BookingUserConfig userConfig);
 }

--- a/src/TennisBooking.Application/Abstractions/INotificationSender.cs
+++ b/src/TennisBooking.Application/Abstractions/INotificationSender.cs
@@ -10,4 +10,5 @@ public interface INotificationSender
         CancellationToken cancellationToken);
 
     Task NotifyMessageAsync(string message, CancellationToken cancellationToken, int? replyToMessageId = null);
+    Task<int> GetThumbsUpReactionCountAsync(long chatId, int messageId, CancellationToken cancellationToken);
 }

--- a/src/TennisBooking.Application/Booking/AttendanceReminderUseCase.cs
+++ b/src/TennisBooking.Application/Booking/AttendanceReminderUseCase.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Logging;
+using TennisBooking.Application.Abstractions;
+
+namespace TennisBooking.Application.Booking;
+
+public sealed class AttendanceReminderUseCase
+{
+    public const string ReminderType24h = "24h";
+    public const string ReminderType2h = "2h";
+
+    private readonly IBookingCancellationLinkRepository _links;
+    private readonly INotificationSender _notification;
+    private readonly ILogger<AttendanceReminderUseCase> _logger;
+
+    public AttendanceReminderUseCase(
+        IBookingCancellationLinkRepository links,
+        INotificationSender notification,
+        ILogger<AttendanceReminderUseCase> logger)
+    {
+        _links = links;
+        _notification = notification;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(long chatId, int telegramMessageId, string reminderType, CancellationToken cancellationToken)
+    {
+        if (reminderType is not (ReminderType24h or ReminderType2h))
+            throw new ArgumentOutOfRangeException(nameof(reminderType), reminderType, "Unsupported attendance reminder type.");
+
+        var link = await _links.GetByMessageAsync(chatId, telegramMessageId, cancellationToken);
+        if (link is null || link.CancelledAtUtc.HasValue)
+        {
+            _logger.LogInformation(
+                "Skipping attendance reminder {ReminderType} for chat {ChatId}, message {MessageId}: booking missing or cancelled",
+                reminderType,
+                chatId,
+                telegramMessageId);
+            return;
+        }
+
+        var marked = await _links.TryMarkReminderSentAsync(chatId, telegramMessageId, reminderType, cancellationToken);
+        if (!marked)
+        {
+            _logger.LogInformation(
+                "Skipping attendance reminder {ReminderType} for chat {ChatId}, message {MessageId}: already sent",
+                reminderType,
+                chatId,
+                telegramMessageId);
+            return;
+        }
+
+        var thumbsUpCount = await _notification.GetThumbsUpReactionCountAsync(chatId, telegramMessageId, cancellationToken);
+        if (thumbsUpCount > 1)
+        {
+            _logger.LogInformation(
+                "Attendance reminder {ReminderType} not needed for chat {ChatId}, message {MessageId}: thumbs-up count is {Count}",
+                reminderType,
+                chatId,
+                telegramMessageId,
+                thumbsUpCount);
+            return;
+        }
+
+        var reminderText = reminderType == ReminderType24h
+            ? "Нагадування: завтра корт заброньований. Якщо ніхто не планує бути присутнім, скасуйте бронювання командою /cancel у відповідь на повідомлення про бронювання."
+            : "Нагадування: гра вже за 2 години. Якщо ніхто не планує бути присутнім, скасуйте бронювання командою /cancel у відповідь на повідомлення про бронювання.";
+
+        await _notification.NotifyMessageAsync(reminderText, cancellationToken, telegramMessageId);
+    }
+}

--- a/src/TennisBooking.Application/Booking/ExecuteBookingUseCase.cs
+++ b/src/TennisBooking.Application/Booking/ExecuteBookingUseCase.cs
@@ -9,6 +9,7 @@ public sealed class ExecuteBookingUseCase
     private readonly INotificationSender _notificationSender;
     private readonly IBookingDeduplicationStore _deduplicationStore;
     private readonly IBookingCancellationLinkRepository _bookingCancellationLinkRepository;
+    private readonly IBookingScheduler _bookingScheduler;
     private readonly ILogger<ExecuteBookingUseCase> _logger;
 
     public ExecuteBookingUseCase(
@@ -16,12 +17,14 @@ public sealed class ExecuteBookingUseCase
         INotificationSender notificationSender,
         IBookingDeduplicationStore deduplicationStore,
         IBookingCancellationLinkRepository bookingCancellationLinkRepository,
+        IBookingScheduler bookingScheduler,
         ILogger<ExecuteBookingUseCase> logger)
     {
         _skeddaClient = skeddaClient;
         _notificationSender = notificationSender;
         _deduplicationStore = deduplicationStore;
         _bookingCancellationLinkRepository = bookingCancellationLinkRepository;
+        _bookingScheduler = bookingScheduler;
         _logger = logger;
     }
 
@@ -69,6 +72,21 @@ public sealed class ExecuteBookingUseCase
                 telegramResult.ChatId,
                 telegramResult.MessageId,
                 bookResult.BookingId);
+
+            var reminder24hAt = booking.Slot.StartTime.ToUniversalTime().AddHours(-24);
+            var reminder2hAt = booking.Slot.StartTime.ToUniversalTime().AddHours(-2);
+            _bookingScheduler.ScheduleAttendanceCheck(
+                telegramResult.ChatId,
+                telegramResult.MessageId,
+                booking.Slot.StartTime.ToUniversalTime(),
+                AttendanceReminderUseCase.ReminderType24h,
+                reminder24hAt);
+            _bookingScheduler.ScheduleAttendanceCheck(
+                telegramResult.ChatId,
+                telegramResult.MessageId,
+                booking.Slot.StartTime.ToUniversalTime(),
+                AttendanceReminderUseCase.ReminderType2h,
+                reminder2hAt);
         }
         catch (Exception ex)
         {

--- a/src/TennisBooking.Infrastructure/Persistence/BookingCancellationLinkRepository.cs
+++ b/src/TennisBooking.Infrastructure/Persistence/BookingCancellationLinkRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using TennisBooking.Application.Abstractions;
+using TennisBooking.Application.Booking;
 using TennisBooking.DAL;
 using TennisBooking.DAL.Models;
 using TennisBooking.Domain.Booking;
@@ -93,7 +94,42 @@ public sealed class BookingCancellationLinkRepository : IBookingCancellationLink
             entity.TelegramMessageId,
             entity.SkeddaBookingId,
             entity.CreatedAtUtc,
-            entity.CancelledAtUtc);
+            entity.CancelledAtUtc,
+            entity.AttendanceReminder24hSentAtUtc,
+            entity.AttendanceReminder2hSentAtUtc);
+    }
+
+    public async Task<BookingCancellationLink?> GetByMessageAsync(long chatId, int telegramMessageId, CancellationToken cancellationToken)
+    {
+        var entity = await _db.BookingCancellationLinks
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                x => x.ChatId == chatId && x.TelegramMessageId == telegramMessageId,
+                cancellationToken);
+
+        if (entity is null)
+            return null;
+
+        var userConfig = new BookingUserConfig(
+            entity.UserConfigId,
+            entity.Username,
+            entity.Password,
+            entity.ResourceId,
+            entity.Venue,
+            entity.VenueUser,
+            entity.DayOfWeek,
+            entity.Hour);
+
+        return new BookingCancellationLink(
+            userConfig,
+            new BookingSlot(entity.SlotStartUtc),
+            entity.ChatId,
+            entity.TelegramMessageId,
+            entity.SkeddaBookingId,
+            entity.CreatedAtUtc,
+            entity.CancelledAtUtc,
+            entity.AttendanceReminder24hSentAtUtc,
+            entity.AttendanceReminder2hSentAtUtc);
     }
 
     public async Task<bool> TryMarkCancelledAsync(long chatId, int repliedTelegramMessageId, int cancelRequestMessageId, CancellationToken cancellationToken)
@@ -119,6 +155,36 @@ public sealed class BookingCancellationLinkRepository : IBookingCancellationLink
             chatId,
             repliedTelegramMessageId,
             cancelRequestMessageId);
+        return true;
+    }
+
+    public async Task<bool> TryMarkReminderSentAsync(long chatId, int telegramMessageId, string reminderType, CancellationToken cancellationToken)
+    {
+        var entity = await _db.BookingCancellationLinks.FirstOrDefaultAsync(
+            x => x.ChatId == chatId && x.TelegramMessageId == telegramMessageId,
+            cancellationToken);
+
+        if (entity is null || entity.CancelledAtUtc.HasValue)
+            return false;
+
+        if (string.Equals(reminderType, AttendanceReminderUseCase.ReminderType24h, StringComparison.Ordinal))
+        {
+            if (entity.AttendanceReminder24hSentAtUtc.HasValue)
+                return false;
+            entity.AttendanceReminder24hSentAtUtc = DateTimeOffset.UtcNow;
+        }
+        else if (string.Equals(reminderType, AttendanceReminderUseCase.ReminderType2h, StringComparison.Ordinal))
+        {
+            if (entity.AttendanceReminder2hSentAtUtc.HasValue)
+                return false;
+            entity.AttendanceReminder2hSentAtUtc = DateTimeOffset.UtcNow;
+        }
+        else
+        {
+            throw new ArgumentOutOfRangeException(nameof(reminderType), reminderType, "Unsupported reminder type.");
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
         return true;
     }
 }

--- a/src/TennisBooking.Infrastructure/Persistence/Models/BookingCancellationLinkEntity.cs
+++ b/src/TennisBooking.Infrastructure/Persistence/Models/BookingCancellationLinkEntity.cs
@@ -19,4 +19,6 @@ public class BookingCancellationLinkEntity
     public DateTimeOffset CreatedAtUtc { get; set; }
     public DateTimeOffset? CancelledAtUtc { get; set; }
     public int? CancelRequestMessageId { get; set; }
+    public DateTimeOffset? AttendanceReminder24hSentAtUtc { get; set; }
+    public DateTimeOffset? AttendanceReminder2hSentAtUtc { get; set; }
 }

--- a/src/TennisBooking.Infrastructure/Scheduling/HangfireBookingScheduler.cs
+++ b/src/TennisBooking.Infrastructure/Scheduling/HangfireBookingScheduler.cs
@@ -28,6 +28,18 @@ public sealed class HangfireBookingScheduler : IBookingScheduler
             x => x.ExecuteAsync(userConfigId, startTime, CancellationToken.None),
             runAt);
 
+    public void ScheduleAttendanceCheck(long chatId, int telegramMessageId, DateTimeOffset slotStartUtc, string reminderType, DateTimeOffset runAtUtc)
+    {
+        _ = slotStartUtc;
+        var target = runAtUtc < DateTimeOffset.UtcNow
+            ? DateTimeOffset.UtcNow.AddSeconds(1)
+            : runAtUtc;
+
+        _backgroundJobClient.Schedule<AttendanceReminderUseCase>(
+            x => x.ExecuteAsync(chatId, telegramMessageId, reminderType, CancellationToken.None),
+            target);
+    }
+
     public void ScheduleRecurringPreparation(BookingUserConfig userConfig)
         => RecurringJob.AddOrUpdate<PrepareBookingForConfigUseCase>(
             userConfig.Username,

--- a/src/TennisBooking.Infrastructure/Telegram/TelegramLongPollingService.cs
+++ b/src/TennisBooking.Infrastructure/Telegram/TelegramLongPollingService.cs
@@ -129,7 +129,7 @@ public sealed class TelegramLongPollingService : BackgroundService
         if (!repliedMessageId.HasValue)
         {
             _logger.LogInformation("Rejecting /cancel message {MessageId}: not sent as reply", message.MessageId);
-            await notification.NotifyMessageAsync("Використай /cancel як відповідь на повідомлення про бронювання.", cancellationToken);
+            await notification.NotifyMessageAsync("Щоб відмінити бронювання, надішліть /cancel у відповідь на повідомлення про бронювання.", cancellationToken);
             return;
         }
 

--- a/src/TennisBooking.Infrastructure/Telegram/TelegramNotificationSender.cs
+++ b/src/TennisBooking.Infrastructure/Telegram/TelegramNotificationSender.cs
@@ -36,7 +36,10 @@ public sealed class TelegramNotificationSender : INotificationSender
         var dayAndDate = slot.StartTime.ToString("dddd d MMMM", ukrainian);
         var startTime = slot.StartTime.ToString("HH:mm", ukrainian);
         var endTime = slot.EndTime.ToString("HH:mm", ukrainian);
-        var message = $"🎾 Забронював тенісний корт в Галактиці, {dayAndDate}, {startTime}–{endTime}";
+        var message =
+            $"🎾 Забронював тенісний корт в Галактиці, {dayAndDate}, {startTime}–{endTime}\n" +
+            "Якщо плануєш бути на грі, постав 👍 на це повідомлення.\n" +
+            "Щоб відмінити бронювання, надішліть /cancel у відповідь на повідомлення про бронювання.";
 
         try
         {
@@ -51,6 +54,42 @@ public sealed class TelegramNotificationSender : INotificationSender
 
     public async Task NotifyMessageAsync(string message, CancellationToken cancellationToken, int? replyToMessageId = null)
         => await SendMessageInternalAsync(message, null, cancellationToken, replyToMessageId);
+
+    public async Task<int> GetThumbsUpReactionCountAsync(long chatId, int messageId, CancellationToken cancellationToken)
+    {
+        var url = $"{BaseUrlPrefix}{_options.BotToken}/getMessageReactions";
+        var payload = new Dictionary<string, object?>
+        {
+            ["chat_id"] = chatId,
+            ["message_id"] = messageId
+        };
+        var content = new StringContent(
+            JsonSerializer.Serialize(payload),
+            Encoding.UTF8);
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+        var resp = await _http.PostAsync(url, content, cancellationToken);
+        resp.EnsureSuccessStatusCode();
+        var json = await resp.Content.ReadAsStringAsync(cancellationToken);
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("result", out var result) || result.ValueKind != JsonValueKind.Array)
+            return 0;
+
+        var count = 0;
+        foreach (var reaction in result.EnumerateArray())
+        {
+            if (!reaction.TryGetProperty("type", out var typeNode) || typeNode.GetString() != "emoji")
+                continue;
+            if (!reaction.TryGetProperty("emoji", out var emojiNode) || emojiNode.GetString() != "👍")
+                continue;
+            if (!reaction.TryGetProperty("total_count", out var countNode))
+                continue;
+
+            count = countNode.GetInt32();
+            break;
+        }
+
+        return count;
+    }
 
     private async Task<TelegramNotificationResult> SendMessageInternalAsync(
         string message,

--- a/src/TennisBooking/Migrations/20260522170000_AddAttendanceReminderState.Designer.cs
+++ b/src/TennisBooking/Migrations/20260522170000_AddAttendanceReminderState.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TennisBooking.DAL;
@@ -11,9 +12,11 @@ using TennisBooking.DAL;
 namespace TennisBooking.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260522170000_AddAttendanceReminderState")]
+    partial class AddAttendanceReminderState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -30,14 +33,14 @@ namespace TennisBooking.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
-                    b.Property<int?>("CancelRequestMessageId")
-                        .HasColumnType("integer");
-
                     b.Property<DateTimeOffset?>("AttendanceReminder24hSentAtUtc")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset?>("AttendanceReminder2hSentAtUtc")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<int?>("CancelRequestMessageId")
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset?>("CancelledAtUtc")
                         .HasColumnType("timestamp with time zone");

--- a/src/TennisBooking/Migrations/20260522170000_AddAttendanceReminderState.cs
+++ b/src/TennisBooking/Migrations/20260522170000_AddAttendanceReminderState.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TennisBooking.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAttendanceReminderState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "AttendanceReminder24hSentAtUtc",
+                table: "BookingCancellationLinks",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "AttendanceReminder2hSentAtUtc",
+                table: "BookingCancellationLinks",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AttendanceReminder24hSentAtUtc",
+                table: "BookingCancellationLinks");
+
+            migrationBuilder.DropColumn(
+                name: "AttendanceReminder2hSentAtUtc",
+                table: "BookingCancellationLinks");
+        }
+    }
+}

--- a/src/TennisBooking/Program.cs
+++ b/src/TennisBooking/Program.cs
@@ -63,6 +63,7 @@ builder.Services.AddScoped<PrepareBookingUseCase>();
 builder.Services.AddScoped<PrepareBookingForConfigUseCase>();
 builder.Services.AddScoped<ExecuteBookingUseCase>();
 builder.Services.AddScoped<BookingFallbackUseCase>();
+builder.Services.AddScoped<AttendanceReminderUseCase>();
 builder.Services.AddScoped<ScheduleBookingsUseCase>();
 builder.Services.AddControllers();
 builder.Services.AddHealthChecks()

--- a/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
+++ b/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
@@ -100,6 +100,7 @@ public sealed class BookingPostgresIntegrationTests
             notification.Object,
             new InMemoryBookingDeduplicationStore(),
             new BookingCancellationLinkRepository(db, NullLogger<BookingCancellationLinkRepository>.Instance),
+            Mock.Of<IBookingScheduler>(),
             NullLogger<ExecuteBookingUseCase>.Instance);
         var fallback = new BookingFallbackUseCase(new UserBookingConfigRepository(db), skeddaClient, execute);
         var startTime = new DateTimeOffset(2030, 1, 1, userConfig.Hour, 0, 0, TimeSpan.Zero);
@@ -143,6 +144,7 @@ public sealed class BookingPostgresIntegrationTests
             notification.Object,
             dedupe,
             new BookingCancellationLinkRepository(db, NullLogger<BookingCancellationLinkRepository>.Instance),
+            Mock.Of<IBookingScheduler>(),
             NullLogger<ExecuteBookingUseCase>.Instance);
         var fallback = new BookingFallbackUseCase(new UserBookingConfigRepository(db), skeddaClient, execute);
         var startTime = new DateTimeOffset(2030, 1, 1, userConfig.Hour, 0, 0, TimeSpan.Zero);

--- a/tests/TennisBooking.Tests/UnitTests.cs
+++ b/tests/TennisBooking.Tests/UnitTests.cs
@@ -77,6 +77,7 @@ public class UnitTests
             notification.Object,
             new InMemoryBookingDeduplicationStore(),
             Mock.Of<IBookingCancellationLinkRepository>(),
+            Mock.Of<IBookingScheduler>(),
             NullLogger<ExecuteBookingUseCase>.Instance);
         var booking = Prepared(BasicDomainConfig(), new BookingSlot(new DateTimeOffset(2030, 6, 15, 10, 0, 0, TimeSpan.Zero)));
 
@@ -109,6 +110,7 @@ public class UnitTests
             notification.Object,
             new InMemoryBookingDeduplicationStore(),
             Mock.Of<IBookingCancellationLinkRepository>(),
+            Mock.Of<IBookingScheduler>(),
             NullLogger<ExecuteBookingUseCase>.Instance);
         var fallback = new BookingFallbackUseCase(new UserBookingConfigRepository(db), skedda.Object, execute);
 
@@ -129,10 +131,68 @@ public class UnitTests
                 Mock.Of<INotificationSender>(),
                 new InMemoryBookingDeduplicationStore(),
                 Mock.Of<IBookingCancellationLinkRepository>(),
+                Mock.Of<IBookingScheduler>(),
                 NullLogger<ExecuteBookingUseCase>.Instance));
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             fallback.ExecuteAsync(999, DateTimeOffset.UtcNow, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task AttendanceReminder_SendsMessage_WhenThumbsUpCountIsLow()
+    {
+        var link = new BookingCancellationLink(
+            BasicDomainConfig(),
+            new BookingSlot(new DateTimeOffset(2030, 6, 15, 10, 0, 0, TimeSpan.Zero)),
+            5,
+            10,
+            "skedda-1",
+            DateTimeOffset.UtcNow,
+            null,
+            null,
+            null);
+        var links = new Mock<IBookingCancellationLinkRepository>();
+        links.Setup(x => x.GetByMessageAsync(5, 10, It.IsAny<CancellationToken>())).ReturnsAsync(link);
+        links.Setup(x => x.TryMarkReminderSentAsync(5, 10, AttendanceReminderUseCase.ReminderType24h, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var notification = new Mock<INotificationSender>();
+        notification.Setup(x => x.GetThumbsUpReactionCountAsync(5, 10, It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        var useCase = new AttendanceReminderUseCase(links.Object, notification.Object, NullLogger<AttendanceReminderUseCase>.Instance);
+
+        await useCase.ExecuteAsync(5, 10, AttendanceReminderUseCase.ReminderType24h, CancellationToken.None);
+
+        notification.Verify(
+            x => x.NotifyMessageAsync(
+                It.Is<string>(text => text.Contains("завтра корт заброньований", StringComparison.Ordinal)),
+                It.IsAny<CancellationToken>(),
+                10),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AttendanceReminder_DoesNotSend_WhenThumbsUpCountIsEnough()
+    {
+        var link = new BookingCancellationLink(
+            BasicDomainConfig(),
+            new BookingSlot(new DateTimeOffset(2030, 6, 15, 10, 0, 0, TimeSpan.Zero)),
+            5,
+            10,
+            "skedda-1",
+            DateTimeOffset.UtcNow,
+            null,
+            null,
+            null);
+        var links = new Mock<IBookingCancellationLinkRepository>();
+        links.Setup(x => x.GetByMessageAsync(5, 10, It.IsAny<CancellationToken>())).ReturnsAsync(link);
+        links.Setup(x => x.TryMarkReminderSentAsync(5, 10, AttendanceReminderUseCase.ReminderType2h, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var notification = new Mock<INotificationSender>();
+        notification.Setup(x => x.GetThumbsUpReactionCountAsync(5, 10, It.IsAny<CancellationToken>())).ReturnsAsync(2);
+        var useCase = new AttendanceReminderUseCase(links.Object, notification.Object, NullLogger<AttendanceReminderUseCase>.Instance);
+
+        await useCase.ExecuteAsync(5, 10, AttendanceReminderUseCase.ReminderType2h, CancellationToken.None);
+
+        notification.Verify(x => x.NotifyMessageAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<int?>()), Times.Never);
     }
 
     [Fact]
@@ -330,6 +390,8 @@ public class UnitTests
             FallbackUserConfigId = userConfigId;
             FallbackStartTime = startTime;
         }
+
+        public void ScheduleAttendanceCheck(long chatId, int telegramMessageId, DateTimeOffset slotStartUtc, string reminderType, DateTimeOffset runAtUtc) { }
 
         public void ScheduleRecurringPreparation(BookingUserConfig userConfig) { }
     }


### PR DESCRIPTION
## Summary
- update booking success message to ask all participants to react with 👍
- add attendance reminder jobs at 24h and 2h before slot start
- check exact 👍 reaction count and notify only when count is 0 or 1
- keep cancellation manual and clarify reminder text to reply /cancel to the booking message
- improve invalid /cancel instruction wording in Telegram polling flow
- persist reminder sent markers to avoid duplicate notifications

## Technical changes
- added AttendanceReminderUseCase and wired Hangfire scheduling from ExecuteBookingUseCase
- extended abstractions: scheduler, notification sender, cancellation link repository
- added Telegram reaction read via getMessageReactions and thumbs-up counting
- added DB migration for attendance reminder sent timestamps
- updated unit/integration tests for new constructor dependencies and reminder behavior

## Validation
- dotnet test tests/TennisBooking.Tests/TennisBooking.Tests.csproj
