### PR TITLE
Reuse a pooled, pre-warmed connection for Skedda bookings

### DIFF
--- a/src/TennisBooking.Application/Abstractions/ISkeddaClient.cs
+++ b/src/TennisBooking.Application/Abstractions/ISkeddaClient.cs
@@ -7,5 +7,12 @@ public interface ISkeddaClient
 {
     Task<PreparedBooking> PrepareBookingAsync(BookingUserConfig userConfig, BookingSlot slot, CancellationToken cancellationToken);
     Task<SkeddaBookingResult> BookAsync(PreparedBooking booking, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Best-effort pre-warm of the pooled connection to Skedda so the booking POST reuses an
+    /// already-established TCP+TLS connection. Never throws (except on cancellation).
+    /// </summary>
+    Task WarmupAsync(PreparedBooking booking, CancellationToken cancellationToken);
+
     Task CancelAsync(PreparedBooking booking, string bookingId, CancellationToken cancellationToken);
 }

--- a/src/TennisBooking.Application/Booking/CancelBookingUseCase.cs
+++ b/src/TennisBooking.Application/Booking/CancelBookingUseCase.cs
@@ -34,10 +34,12 @@ public sealed class CancelBookingUseCase
 
         if (!link.CancelledAtUtc.HasValue)
         {
+            // Inert placeholder: CancelAsync builds its own session and never reads BodyJson/CookieHeader.
             var prepared = new PreparedBooking(
                 link.UserConfig,
                 link.Slot,
-                new { },
+                string.Empty,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty);

--- a/src/TennisBooking.Application/Booking/PreparedBooking.cs
+++ b/src/TennisBooking.Application/Booking/PreparedBooking.cs
@@ -5,7 +5,11 @@ namespace TennisBooking.Application.Booking;
 public sealed record PreparedBooking(
     BookingUserConfig UserConfig,
     BookingSlot Slot,
-    object Body,
+    // Pre-serialized JSON request body and pre-built Cookie header, computed during
+    // PrepareBookingAsync so nothing but the network send happens at the target instant.
+    // Safe to pre-compute because nothing mutates UserConfig/Slot after preparation.
+    string BodyJson,
+    string CookieHeader,
     string RequestVerificationToken,
     string CsrfCookie,
     string ApplicationCookie);

--- a/src/TennisBooking.Infrastructure/Scheduling/PreciseBookingScheduler.cs
+++ b/src/TennisBooking.Infrastructure/Scheduling/PreciseBookingScheduler.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using TennisBooking.Application.Abstractions;
 using TennisBooking.Application.Booking;
 
 namespace TennisBooking.Infrastructure.Scheduling;
@@ -11,6 +12,8 @@ public sealed class PreciseBookingScheduler : IPreciseBookingScheduler, IHostedS
 {
     private static readonly TimeSpan WarmupBeforeTarget = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan PrecisionStep = TimeSpan.FromMilliseconds(20);
+    // A stalled warm-up must never delay the POST: abandon it this far before the target instant.
+    private static readonly TimeSpan WarmupDeadlineMargin = TimeSpan.FromMilliseconds(300);
 
     private readonly ConcurrentDictionary<string, byte> _scheduled = new();
     private readonly IServiceScopeFactory _scopeFactory;
@@ -52,8 +55,31 @@ public sealed class PreciseBookingScheduler : IPreciseBookingScheduler, IHostedS
             var warmupTime = targetTime - WarmupBeforeTarget;
             var now = DateTimeOffset.UtcNow;
 
+            using var scope = _scopeFactory.CreateScope();
+
             if (warmupTime > now)
+            {
                 await Task.Delay(warmupTime - now, token);
+                // Pre-open the pooled TCP+TLS connection so the POST below reuses a warm socket.
+                // Bound it to a deadline before the target so a slow probe can't delay the POST.
+                var remainingToDeadline = (targetTime - WarmupDeadlineMargin) - DateTimeOffset.UtcNow;
+                if (remainingToDeadline > TimeSpan.Zero)
+                {
+                    using var warmupCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+                    warmupCts.CancelAfter(remainingToDeadline);
+                    var skeddaClient = scope.ServiceProvider.GetRequiredService<ISkeddaClient>();
+                    try
+                    {
+                        await skeddaClient.WarmupAsync(booking, warmupCts.Token);
+                    }
+                    catch (OperationCanceledException) when (!token.IsCancellationRequested)
+                    {
+                        _logger.LogWarning(
+                            "Skedda warm-up exceeded its deadline for {Key}; proceeding without a pre-warmed connection",
+                            key);
+                    }
+                }
+            }
 
             while (DateTimeOffset.UtcNow < targetTime)
             {
@@ -63,7 +89,6 @@ public sealed class PreciseBookingScheduler : IPreciseBookingScheduler, IHostedS
                     await Task.Delay(delay, token);
             }
 
-            using var scope = _scopeFactory.CreateScope();
             var executeBooking = scope.ServiceProvider.GetRequiredService<ExecuteBookingUseCase>();
             await executeBooking.ExecuteAsync(booking, token);
             _logger.LogInformation("Precise timer triggered booking for {Username} at {Target}", booking.UserConfig.Username, targetTime);

--- a/src/TennisBooking.Infrastructure/Skedda/SkeddaClient.cs
+++ b/src/TennisBooking.Infrastructure/Skedda/SkeddaClient.cs
@@ -14,6 +14,10 @@ namespace TennisBooking.Infrastructure.Skedda;
 
 public sealed class SkeddaClient : ISkeddaClient
 {
+    // Name of the pooled HttpClient registered via AddHttpClient in Program.cs.
+    // Referenced there so the registration name and the client requested here can't drift.
+    public const string SkeddaHttpClientName = "Skedda";
+
     private const string AccountLoginPath = "/account/login";
     private const string LoginPath = "/logins";
     private const string GetBookingsPath = "/booking";
@@ -23,11 +27,16 @@ public sealed class SkeddaClient : ISkeddaClient
     private const string ApplicationCookieName = "X-Skedda-ApplicationCookie";
     private const string CsrfCookieName = "X-Skedda-RequestVerificationCookie";
 
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly SkeddaOptions _options;
     private readonly ILogger<SkeddaClient> _logger;
 
-    public SkeddaClient(IOptions<SkeddaOptions> options, ILogger<SkeddaClient> logger)
+    public SkeddaClient(
+        IHttpClientFactory httpClientFactory,
+        IOptions<SkeddaOptions> options,
+        ILogger<SkeddaClient> logger)
     {
+        _httpClientFactory = httpClientFactory;
         _options = options.Value;
         _logger = logger;
     }
@@ -43,10 +52,15 @@ public sealed class SkeddaClient : ISkeddaClient
             slot.StartTime);
         var session = await CreateSessionAsync(userConfig, cancellationToken);
         _logger.LogInformation("Prepared Skedda booking session for user {Username}", userConfig.Username);
+        // Pre-serialize the request body and pre-build the Cookie header now (off the hot path),
+        // so BookAsync at the target instant only allocates a StringContent and calls SendAsync.
+        var bodyJson = JsonConvert.SerializeObject(BuildBookingBody(userConfig, slot));
+        var cookieHeader = BuildCookieHeader(session.CsrfCookie, session.ApplicationCookie);
         return new PreparedBooking(
             userConfig,
             slot,
-            BuildBookingBody(userConfig, slot),
+            bodyJson,
+            cookieHeader,
             session.RequestVerificationToken,
             session.CsrfCookie,
             session.ApplicationCookie);
@@ -58,14 +72,14 @@ public sealed class SkeddaClient : ISkeddaClient
             "Sending Skedda booking request for user {Username}, slot {SlotStart}",
             booking.UserConfig.Username,
             booking.Slot.StartTime);
-        var baseUri = new Uri(_options.ApiBaseUrl);
-        using var client = new HttpClient { BaseAddress = baseUri };
+        var client = _httpClientFactory.CreateClient(SkeddaHttpClientName);
 
-        var bookReq = new HttpRequestMessage(HttpMethod.Post, BookingPath);
-        bookReq.Content = JsonContent(booking.Body);
+        using var bookReq = new HttpRequestMessage(HttpMethod.Post, BookingPath)
+        {
+            Content = new StringContent(booking.BodyJson, Encoding.UTF8, "application/json")
+        };
         bookReq.Headers.Add(CsrfHeaderName, booking.RequestVerificationToken);
-        bookReq.Headers.Add(CookieHeaderName,
-            $"{CsrfCookieName}={booking.CsrfCookie}; {ApplicationCookieName}={booking.ApplicationCookie}");
+        bookReq.Headers.Add(CookieHeaderName, booking.CookieHeader);
 
         var bookResp = await client.SendAsync(bookReq, cancellationToken);
         if (!bookResp.IsSuccessStatusCode)
@@ -81,6 +95,45 @@ public sealed class SkeddaClient : ISkeddaClient
         return new SkeddaBookingResult(bookingId);
     }
 
+    public async Task WarmupAsync(PreparedBooking booking, CancellationToken cancellationToken)
+    {
+        // Issue a cheap UNAUTHENTICATED GET on the pooled client during the pre-warm window so the
+        // TCP+TLS handshake (and Front Door edge routing) completes ahead of the target instant,
+        // letting the booking POST reuse an already-established connection. Warming the socket does
+        // not need the session, so we deliberately do NOT replay the CSRF/cookie headers here:
+        // that avoids touching the antiforgery-token page and minimizes anomalous request surface.
+        // ResponseHeadersRead returns as soon as the connection is established and headers arrive.
+        // Best-effort: never throws except on cancellation.
+        try
+        {
+            var client = _httpClientFactory.CreateClient(SkeddaHttpClientName);
+            using var warmReq = new HttpRequestMessage(HttpMethod.Get, AccountLoginPath);
+            using var warmResp = await client.SendAsync(
+                warmReq, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            if (warmResp.IsSuccessStatusCode)
+                _logger.LogInformation(
+                    "Warmed up Skedda connection for user {Username} (status {StatusCode})",
+                    booking.UserConfig.Username,
+                    (int)warmResp.StatusCode);
+            else
+                _logger.LogWarning(
+                    "Skedda warm-up GET returned {StatusCode} for user {Username}",
+                    (int)warmResp.StatusCode,
+                    booking.UserConfig.Username);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Skedda connection warm-up failed for user {Username}; proceeding without a pre-warmed connection",
+                booking.UserConfig.Username);
+        }
+    }
+
     public async Task CancelAsync(PreparedBooking booking, string bookingId, CancellationToken cancellationToken)
     {
         _logger.LogInformation(
@@ -89,12 +142,11 @@ public sealed class SkeddaClient : ISkeddaClient
             booking.UserConfig.Username);
         var session = await CreateSessionAsync(booking.UserConfig, cancellationToken);
 
-        var baseUri = new Uri(_options.ApiBaseUrl);
-        using var client = new HttpClient { BaseAddress = baseUri };
-        var deleteReq = new HttpRequestMessage(HttpMethod.Delete, $"{BookingPath}/{bookingId}");
+        var client = _httpClientFactory.CreateClient(SkeddaHttpClientName);
+        using var deleteReq = new HttpRequestMessage(HttpMethod.Delete, $"{BookingPath}/{bookingId}");
         deleteReq.Headers.Add(CsrfHeaderName, session.RequestVerificationToken);
         deleteReq.Headers.Add(CookieHeaderName,
-            $"{CsrfCookieName}={session.CsrfCookie}; {ApplicationCookieName}={session.ApplicationCookie}");
+            BuildCookieHeader(session.CsrfCookie, session.ApplicationCookie));
 
         var deleteResp = await client.SendAsync(deleteReq, cancellationToken);
         if (!deleteResp.IsSuccessStatusCode)
@@ -150,6 +202,9 @@ public sealed class SkeddaClient : ISkeddaClient
 
     private static StringContent JsonContent(object value)
         => new(JsonConvert.SerializeObject(value), Encoding.UTF8, "application/json");
+
+    private static string BuildCookieHeader(string csrfCookie, string applicationCookie)
+        => $"{CsrfCookieName}={csrfCookie}; {ApplicationCookieName}={applicationCookie}";
 
     private static object BuildBookingBody(BookingUserConfig userConfig, BookingSlot slot)
         => new

--- a/src/TennisBooking/Program.cs
+++ b/src/TennisBooking/Program.cs
@@ -1,8 +1,11 @@
+using System.Net;
+using System.Net.Sockets;
 using Hangfire;
 using Hangfire.PostgreSql;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -26,6 +29,51 @@ var telegramConfig = builder.Configuration.GetSection("Telegram");
 builder.Services.Configure<SkeddaOptions>(skeddaConfig);
 builder.Services.Configure<TelegramOptions>(telegramConfig);
 builder.Services.AddHttpClient<TelegramNotificationSender>();
+
+// Pooled, keep-alive HttpClient for the latency-critical Skedda booking POST.
+// IHttpClientFactory caches a single SocketsHttpHandler for this named client and reuses it
+// across every CreateClient call and across DI scopes, so the TCP+TLS connection established
+// during the pre-warm window (see PreciseBookingScheduler) is still open at the target instant
+// instead of a fresh handshake being paid on the hot path.
+builder.Services.AddHttpClient(SkeddaClient.SkeddaHttpClientName, (sp, client) =>
+    {
+        var opts = sp.GetRequiredService<IOptions<SkeddaOptions>>().Value;
+        client.BaseAddress = new Uri(opts.ApiBaseUrl);
+        // Opportunistically negotiate HTTP/2 via ALPN; silently falls back to HTTP/1.1.
+        client.DefaultRequestVersion = HttpVersion.Version20;
+        client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+    })
+    .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+    {
+        // We attach the session Cookie header manually on every request (BuildCookieHeader).
+        // Disable the handler's own CookieContainer so a Set-Cookie received on a pooled
+        // connection (e.g. during the warm-up GET) can never be auto-appended to a later
+        // request's manual Cookie header and produce a duplicate/conflicting cookie.
+        UseCookies = false,
+        // Keep connections warm for the process lifetime, recycling periodically so we still
+        // pick up Front Door DNS/IP changes.
+        PooledConnectionLifetime = TimeSpan.FromMinutes(10),
+        PooledConnectionIdleTimeout = TimeSpan.FromMinutes(5),
+        // Headroom so concurrent same-window bookings (one warm-up + POST each) never queue for a
+        // connection under an HTTP/1.1 fallback; free under HTTP/2 where a connection multiplexes.
+        MaxConnectionsPerServer = 10,
+        EnableMultipleHttp2Connections = true,
+        // Disable Nagle's algorithm (TCP_NODELAY) so the small booking POST is flushed immediately.
+        ConnectCallback = async (context, cancellationToken) =>
+        {
+            var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            try
+            {
+                await socket.ConnectAsync(context.DnsEndPoint, cancellationToken);
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch
+            {
+                socket.Dispose();
+                throw;
+            }
+        }
+    });
 
 var connString = builder.Configuration.GetConnectionString("Default")
                  ?? throw new InvalidOperationException("Connection string 'Default' not found.");
@@ -58,7 +106,9 @@ builder.Services.AddScoped<IUserBookingConfigRepository, UserBookingConfigReposi
 builder.Services.AddScoped<IBookingCancellationLinkRepository, BookingCancellationLinkRepository>();
 builder.Services.AddScoped<ITelegramPollingStateRepository, TelegramPollingStateRepository>();
 builder.Services.AddScoped<ITelegramChatRepository, TelegramChatRepository>();
-builder.Services.AddScoped<ISkeddaClient, SkeddaClient>();
+// Singleton: SkeddaClient now holds only IHttpClientFactory + IOptions + ILogger (all singleton-safe)
+// and no per-request mutable state, so a single instance avoids per-scope allocation on the hot path.
+builder.Services.AddSingleton<ISkeddaClient, SkeddaClient>();
 builder.Services.AddScoped<INotificationSender, TelegramNotificationSender>();
 builder.Services.AddHostedService<TelegramLongPollingService>();
 builder.Services.AddScoped<IBookingScheduler, HangfireBookingScheduler>();

--- a/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
+++ b/tests/TennisBooking.Tests/Integration/BookingPostgresIntegrationTests.cs
@@ -43,6 +43,7 @@ public sealed class BookingPostgresIntegrationTests
         var scheduler = new HangfireBookingScheduler(backgroundJobs, Mock.Of<IPreciseBookingScheduler>());
         var service = new PrepareBookingUseCase(
             new SkeddaClient(
+                new SingleClientHttpClientFactory(skedda.BaseUrl),
                 Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }),
                 NullLogger<SkeddaClient>.Instance),
             scheduler,
@@ -90,6 +91,7 @@ public sealed class BookingPostgresIntegrationTests
         await db.SaveChangesAsync();
 
         var skeddaClient = new SkeddaClient(
+            new SingleClientHttpClientFactory(skedda.BaseUrl),
             Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }),
             NullLogger<SkeddaClient>.Instance);
         var notification = new Mock<INotificationSender>();
@@ -136,6 +138,7 @@ public sealed class BookingPostgresIntegrationTests
         notification.Setup(x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new TelegramNotificationResult(5, 10));
         var skeddaClient = new SkeddaClient(
+            new SingleClientHttpClientFactory(skedda.BaseUrl),
             Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }),
             NullLogger<SkeddaClient>.Instance);
         var dedupe = new InMemoryBookingDeduplicationStore();
@@ -152,7 +155,8 @@ public sealed class BookingPostgresIntegrationTests
         await execute.ExecuteAsync(new PreparedBooking(
             ToDomain(userConfig),
             new BookingSlot(startTime),
-            new { booking = new { spaces = new[] { userConfig.ResourceId } } },
+            "{\"booking\":{\"spaces\":[\"" + userConfig.ResourceId + "\"]}}",
+            "X-Skedda-RequestVerificationCookie=csrf; X-Skedda-ApplicationCookie=app",
             "token",
             "csrf",
             "app"), CancellationToken.None);
@@ -193,7 +197,8 @@ public sealed class BookingPostgresIntegrationTests
         await execute.ExecuteAsync(new PreparedBooking(
             ToDomain(NewConfig("reminder-cancel")),
             slot,
-            new { },
+            "{}",
+            "X-Skedda-RequestVerificationCookie=csrf; X-Skedda-ApplicationCookie=app",
             "token",
             "csrf",
             "app"), CancellationToken.None);
@@ -313,6 +318,13 @@ public sealed class BookingPostgresIntegrationTests
     {
         public FixedClock(DateTimeOffset utcNow) => UtcNow = utcNow;
         public DateTimeOffset UtcNow { get; }
+    }
+
+    private sealed class SingleClientHttpClientFactory : IHttpClientFactory
+    {
+        private readonly string _baseUrl;
+        public SingleClientHttpClientFactory(string baseUrl) => _baseUrl = baseUrl;
+        public HttpClient CreateClient(string name) => new() { BaseAddress = new Uri(_baseUrl) };
     }
 
     private sealed class DockerFactAttribute : FactAttribute

--- a/tests/TennisBooking.Tests/UnitTests.cs
+++ b/tests/TennisBooking.Tests/UnitTests.cs
@@ -413,6 +413,7 @@ public class UnitTests
         });
 
         var client = new SkeddaClient(
+            new SingleClientHttpClientFactory(server.BaseUrl),
             Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = server.BaseUrl }),
             NullLogger<SkeddaClient>.Instance);
 
@@ -432,6 +433,7 @@ public class UnitTests
             return """{"booking":{"id":"1"}}""";
         });
         var client = new SkeddaClient(
+            new SingleClientHttpClientFactory(skedda.BaseUrl),
             Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = skedda.BaseUrl }),
             NullLogger<SkeddaClient>.Instance);
         var booking = Prepared(BasicDomainConfig(), new BookingSlot(DateTimeOffset.UtcNow));
@@ -628,10 +630,18 @@ public class UnitTests
     private static PreparedBooking Prepared(BookingUserConfig user, BookingSlot slot) => new(
         user,
         slot,
-        new { booking = new { spaces = new[] { user.ResourceId } } },
+        "{\"booking\":{\"spaces\":[\"" + user.ResourceId + "\"]}}",
+        "X-Skedda-RequestVerificationCookie=csrf; X-Skedda-ApplicationCookie=app",
         "token",
         "csrf",
         "app");
+
+    private sealed class SingleClientHttpClientFactory : IHttpClientFactory
+    {
+        private readonly string _baseUrl;
+        public SingleClientHttpClientFactory(string baseUrl) => _baseUrl = baseUrl;
+        public HttpClient CreateClient(string name) => new() { BaseAddress = new Uri(_baseUrl) };
+    }
 
     private static BookingCancellationLink BookingLink(
         DateTimeOffset? cancelledAtUtc,


### PR DESCRIPTION
## Why

The bot races other users to POST a booking the instant a slot's window opens. Grafana logs showed our POST firing on time (<10ms after target) yet losing to a competitor during a ~683ms round trip. The biggest self-inflicted cost: **every** `BookAsync`/`CancelAsync` created a fresh `HttpClient`, paying a full TCP+TLS handshake on the critical path.

## What

**Connection pooling + protocol tuning**
- Pooled named `HttpClient` via `IHttpClientFactory` + a shared `SocketsHttpHandler` (keep-alive, HTTP/2 with HTTP/1.1 fallback, `TCP_NODELAY`, `UseCookies=false`, `MaxConnectionsPerServer=10`).
- `BookAsync`/`CancelAsync` draw from the pool instead of `new HttpClient()`. `ISkeddaClient` is now a singleton (holds only factory/options/logger — no per-request state).
- `CreateSessionAsync` keeps its own cookie-container handler (runs ~1 min before the race, off the hot path).

**Critical-path pre-compute**
- `PreparedBooking.Body(object)` → pre-serialized `BodyJson(string)` + pre-built `CookieHeader(string)`, computed in `PrepareBookingAsync`. At the target instant `BookAsync` only allocates a `StringContent` and calls `SendAsync`.

**Connection pre-warm**
- The previously-idle 2s warm-up window now issues a cheap **unauthenticated** GET on the pooled client so the TCP+TLS handshake completes before the POST. Bounded by a deadline (300ms before target) so a slow probe can never delay the POST.

## Verification
- Build clean; 23 unit tests pass. Postgres integration tests updated for the new constructor/record shape (self-skip without Docker).
- Reviewed by a multi-lens adversarial pass (5 independent reviewers + per-finding verification). Fixes that came out of it: cookie duplication from `UseCookies=true`, unbounded warm-up, connection starvation, and CSRF-token/WAF surface from an authenticated warm-up.

## Notes / follow-ups
- No 429/rate-limit handling yet (pre-existing) — deferred to the burst-firing work.
- Recommend confirming via the existing OTel HTTP-client spans that the connect/TLS phase drops off the booking POST after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)