### PR TITLE
Fix attendance reminders never being delivered to chat

### DIFF
--- a/src/TennisBooking.Application/Abstractions/INotificationSender.cs
+++ b/src/TennisBooking.Application/Abstractions/INotificationSender.cs
@@ -10,5 +10,4 @@ public interface INotificationSender
         CancellationToken cancellationToken);
 
     Task NotifyMessageAsync(string message, CancellationToken cancellationToken, int? replyToMessageId = null);
-    Task<int> GetThumbsUpReactionCountAsync(long chatId, int messageId, CancellationToken cancellationToken);
 }

--- a/src/TennisBooking.Application/Booking/AttendanceReminderUseCase.cs
+++ b/src/TennisBooking.Application/Booking/AttendanceReminderUseCase.cs
@@ -38,8 +38,10 @@ public sealed class AttendanceReminderUseCase
             return;
         }
 
-        var marked = await _links.TryMarkReminderSentAsync(chatId, telegramMessageId, reminderType, cancellationToken);
-        if (!marked)
+        var alreadySent = reminderType == ReminderType24h
+            ? link.AttendanceReminder24hSentAtUtc.HasValue
+            : link.AttendanceReminder2hSentAtUtc.HasValue;
+        if (alreadySent)
         {
             _logger.LogInformation(
                 "Skipping attendance reminder {ReminderType} for chat {ChatId}, message {MessageId}: already sent",
@@ -49,22 +51,20 @@ public sealed class AttendanceReminderUseCase
             return;
         }
 
-        var thumbsUpCount = await _notification.GetThumbsUpReactionCountAsync(chatId, telegramMessageId, cancellationToken);
-        if (thumbsUpCount > 1)
-        {
-            _logger.LogInformation(
-                "Attendance reminder {ReminderType} not needed for chat {ChatId}, message {MessageId}: thumbs-up count is {Count}",
-                reminderType,
-                chatId,
-                telegramMessageId,
-                thumbsUpCount);
-            return;
-        }
-
         var reminderText = reminderType == ReminderType24h
             ? "Нагадування: завтра корт заброньований. Якщо ніхто не планує бути присутнім, скасуйте бронювання командою /cancel у відповідь на повідомлення про бронювання."
             : "Нагадування: гра вже за 2 години. Якщо ніхто не планує бути присутнім, скасуйте бронювання командою /cancel у відповідь на повідомлення про бронювання.";
 
         await _notification.NotifyMessageAsync(reminderText, cancellationToken, telegramMessageId);
+
+        // Mark as sent only after a successful delivery. If the send throws, the flag stays
+        // unset so Hangfire's retry re-sends, rather than permanently suppressing the reminder.
+        await _links.TryMarkReminderSentAsync(chatId, telegramMessageId, reminderType, cancellationToken);
+
+        _logger.LogInformation(
+            "Attendance reminder {ReminderType} sent for chat {ChatId}, message {MessageId}",
+            reminderType,
+            chatId,
+            telegramMessageId);
     }
 }

--- a/src/TennisBooking.Infrastructure/Telegram/TelegramNotificationSender.cs
+++ b/src/TennisBooking.Infrastructure/Telegram/TelegramNotificationSender.cs
@@ -58,42 +58,6 @@ public sealed class TelegramNotificationSender : INotificationSender
     public async Task NotifyMessageAsync(string message, CancellationToken cancellationToken, int? replyToMessageId = null)
         => await SendMessageInternalAsync(message, null, cancellationToken, replyToMessageId);
 
-    public async Task<int> GetThumbsUpReactionCountAsync(long chatId, int messageId, CancellationToken cancellationToken)
-    {
-        var url = $"{BaseUrlPrefix}{_options.BotToken}/getMessageReactions";
-        var payload = new Dictionary<string, object?>
-        {
-            ["chat_id"] = chatId,
-            ["message_id"] = messageId
-        };
-        var content = new StringContent(
-            JsonSerializer.Serialize(payload),
-            Encoding.UTF8);
-        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-        var resp = await _http.PostAsync(url, content, cancellationToken);
-        resp.EnsureSuccessStatusCode();
-        var json = await resp.Content.ReadAsStringAsync(cancellationToken);
-        using var doc = JsonDocument.Parse(json);
-        if (!doc.RootElement.TryGetProperty("result", out var result) || result.ValueKind != JsonValueKind.Array)
-            return 0;
-
-        var count = 0;
-        foreach (var reaction in result.EnumerateArray())
-        {
-            if (!reaction.TryGetProperty("type", out var typeNode) || typeNode.GetString() != "emoji")
-                continue;
-            if (!reaction.TryGetProperty("emoji", out var emojiNode) || emojiNode.GetString() != "👍")
-                continue;
-            if (!reaction.TryGetProperty("total_count", out var countNode))
-                continue;
-
-            count = countNode.GetInt32();
-            break;
-        }
-
-        return count;
-    }
-
     private async Task<TelegramNotificationResult> SendMessageInternalAsync(
         string message,
         string? parseMode,

--- a/tests/TennisBooking.Tests/UnitTests.cs
+++ b/tests/TennisBooking.Tests/UnitTests.cs
@@ -286,7 +286,7 @@ public class UnitTests
     }
 
     [Fact]
-    public async Task AttendanceReminder_SendsMessage_WhenThumbsUpCountIsLow()
+    public async Task AttendanceReminder_SendsMessageAndMarksSent_WhenNotYetSent()
     {
         var link = new BookingCancellationLink(
             BasicDomainConfig(),
@@ -303,7 +303,6 @@ public class UnitTests
         links.Setup(x => x.TryMarkReminderSentAsync(5, 10, AttendanceReminderUseCase.ReminderType24h, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         var notification = new Mock<INotificationSender>();
-        notification.Setup(x => x.GetThumbsUpReactionCountAsync(5, 10, It.IsAny<CancellationToken>())).ReturnsAsync(1);
         var useCase = new AttendanceReminderUseCase(links.Object, notification.Object, NullLogger<AttendanceReminderUseCase>.Instance);
 
         await useCase.ExecuteAsync(5, 10, AttendanceReminderUseCase.ReminderType24h, CancellationToken.None);
@@ -314,10 +313,12 @@ public class UnitTests
                 It.IsAny<CancellationToken>(),
                 10),
             Times.Once);
+        // The reminder is only marked as sent after a successful delivery.
+        links.Verify(x => x.TryMarkReminderSentAsync(5, 10, AttendanceReminderUseCase.ReminderType24h, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task AttendanceReminder_DoesNotSend_WhenThumbsUpCountIsEnough()
+    public async Task AttendanceReminder_DoesNotSend_WhenAlreadySent()
     {
         var link = new BookingCancellationLink(
             BasicDomainConfig(),
@@ -328,18 +329,16 @@ public class UnitTests
             DateTimeOffset.UtcNow,
             null,
             null,
-            null);
+            DateTimeOffset.UtcNow);
         var links = new Mock<IBookingCancellationLinkRepository>();
         links.Setup(x => x.GetByMessageAsync(5, 10, It.IsAny<CancellationToken>())).ReturnsAsync(link);
-        links.Setup(x => x.TryMarkReminderSentAsync(5, 10, AttendanceReminderUseCase.ReminderType2h, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
         var notification = new Mock<INotificationSender>();
-        notification.Setup(x => x.GetThumbsUpReactionCountAsync(5, 10, It.IsAny<CancellationToken>())).ReturnsAsync(2);
         var useCase = new AttendanceReminderUseCase(links.Object, notification.Object, NullLogger<AttendanceReminderUseCase>.Instance);
 
         await useCase.ExecuteAsync(5, 10, AttendanceReminderUseCase.ReminderType2h, CancellationToken.None);
 
         notification.Verify(x => x.NotifyMessageAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<int?>()), Times.Never);
+        links.Verify(x => x.TryMarkReminderSentAsync(It.IsAny<long>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`AttendanceReminderUseCase` never delivered any reminder to the chat. Loki confirmed that over the last 14 days **every** reminder job (24h and 2h, every booking) failed identically, and not a single reminder was ever sent.

Two compounding bugs:

1. **Non-existent Telegram API.** `GetThumbsUpReactionCountAsync` called `POST .../getMessageReactions`, which **is not a Bot API method**, so every call returned **404** and `EnsureSuccessStatusCode()` threw. (Bots can't pull reaction counts on demand — reactions only arrive via `message_reaction` update events.)

2. **Mark-sent-before-send ordering.** `ExecuteAsync` marked the reminder sent (committed to DB) *before* the reaction check and the actual send. So the first run stamped the `SentAtUtc` flag, then threw on the 404; the Hangfire retry hit the `already sent` guard and returned without sending. The reminder text at the send step was never reached, yet the reminder was permanently marked sent.

Loki evidence — every run:
```
System.Net.Http.HttpRequestException: Response status code does not indicate success: 404 (Not Found).
   at TelegramNotificationSender.GetThumbsUpReactionCountAsync(...) line 73
   at AttendanceReminderUseCase.ExecuteAsync(...) line 52
```
...followed only by `Skipping attendance reminder … already sent`, with zero successful sends.

## Fix

- Drop the broken 👍 gate entirely (removed `GetThumbsUpReactionCountAsync` from `INotificationSender` and `TelegramNotificationSender`).
- Reorder `ExecuteAsync`: **send first, then mark sent**, so a delivery failure is retried by Hangfire instead of being permanently suppressed.
- Add a success log line for observability (there was none before).
- Update unit tests to the new send-then-mark behavior.

## Compatibility with already-scheduled jobs

`ExecuteAsync`'s signature is unchanged, so already-enqueued Hangfire jobs deserialize and run against the new code. Future reminders work correctly. Reminders that already fired-and-failed stay lost (their flag is stamped and their job already completed) — this only affects bookings whose 24h/2h mark has already passed.

## Testing

`dotnet build` clean; `dotnet test` — 27/27 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)