### PR TITLE
Staggered prefire booking burst over HTTP/2

### DIFF
--- a/TennisBooking.slnx
+++ b/TennisBooking.slnx
@@ -2,4 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/TennisBooking/TennisBooking.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/TennisBooking.Tests/TennisBooking.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/src/TennisBooking.Application/Abstractions/ISkeddaClient.cs
+++ b/src/TennisBooking.Application/Abstractions/ISkeddaClient.cs
@@ -10,9 +10,10 @@ public interface ISkeddaClient
 
     /// <summary>
     /// Best-effort pre-warm of the pooled connection to Skedda so the booking POST reuses an
-    /// already-established TCP+TLS connection. Never throws (except on cancellation).
+    /// already-established TCP+TLS connection, and (as a side effect) sample the server clock. Never
+    /// throws except on cancellation; returns <see cref="SkeddaWarmupResult.Established"/> = false on failure.
     /// </summary>
-    Task WarmupAsync(PreparedBooking booking, CancellationToken cancellationToken);
+    Task<SkeddaWarmupResult> WarmupAsync(PreparedBooking booking, CancellationToken cancellationToken);
 
     Task CancelAsync(PreparedBooking booking, string bookingId, CancellationToken cancellationToken);
 }

--- a/src/TennisBooking.Application/Abstractions/SkeddaBookingRejectedException.cs
+++ b/src/TennisBooking.Application/Abstractions/SkeddaBookingRejectedException.cs
@@ -1,0 +1,17 @@
+namespace TennisBooking.Application.Abstractions;
+
+/// <summary>
+/// Thrown by <see cref="ISkeddaClient.BookAsync"/> when Skedda rejects the booking for an expected,
+/// business reason — the slot is already taken, or it is not open yet. This is the normal outcome of
+/// losing (or being early in) the race for a contested slot, and is distinct from an infrastructure or
+/// authentication failure, which surfaces as a different exception so the caller can log it loudly
+/// instead of treating it as a routine lost race.
+/// </summary>
+public sealed class SkeddaBookingRejectedException : Exception
+{
+    public int StatusCode { get; }
+
+    public SkeddaBookingRejectedException(int statusCode, string responseBody)
+        : base($"Skedda rejected the booking (status {statusCode}): {responseBody}")
+        => StatusCode = statusCode;
+}

--- a/src/TennisBooking.Application/Abstractions/SkeddaWarmupResult.cs
+++ b/src/TennisBooking.Application/Abstractions/SkeddaWarmupResult.cs
@@ -1,0 +1,12 @@
+namespace TennisBooking.Application.Abstractions;
+
+/// <summary>
+/// Outcome of a single pre-open warm-up probe.
+/// </summary>
+/// <param name="Established">True if the probe completed a request (so the pooled TCP+TLS connection is warm).</param>
+/// <param name="ClockSkew">
+/// Estimated offset between the Skedda server clock and this host's clock (server minus host), derived
+/// from the response <c>Date</c> header adjusted for round-trip, or null if the header was absent. The
+/// Date header is second-resolution, so treat this as coarse.
+/// </param>
+public sealed record SkeddaWarmupResult(bool Established, TimeSpan? ClockSkew);

--- a/src/TennisBooking.Application/Booking/ExecuteBookingUseCase.cs
+++ b/src/TennisBooking.Application/Booking/ExecuteBookingUseCase.cs
@@ -52,65 +52,7 @@ public sealed class ExecuteBookingUseCase
                 booking.Slot.StartTime);
 
             var bookResult = await _skeddaClient.BookAsync(booking, cancellationToken);
-            _logger.LogInformation("Skedda booking created with id {SkeddaBookingId}", bookResult.BookingId);
-
-            var telegramResult = await _notificationSender.NotifyBookingSucceededAsync(booking.UserConfig, booking.Slot, cancellationToken);
-            _logger.LogInformation(
-                "Telegram success notification sent: chat {ChatId}, message {MessageId}",
-                telegramResult.ChatId,
-                telegramResult.MessageId);
-
-            if (telegramResult.ChatId == 0 || telegramResult.MessageId == 0)
-            {
-                _logger.LogWarning(
-                    "Skipping Telegram cancellation link and attendance reminders because no Telegram message was sent");
-                return;
-            }
-
-            await _bookingCancellationLinkRepository.SaveAsync(
-                booking.UserConfig,
-                booking.Slot,
-                telegramResult.ChatId,
-                telegramResult.MessageId,
-                bookResult.BookingId,
-                cancellationToken);
-            _logger.LogInformation(
-                "Stored cancellation link: chat {ChatId}, message {MessageId}, booking {SkeddaBookingId}",
-                telegramResult.ChatId,
-                telegramResult.MessageId,
-                bookResult.BookingId);
-
-            var reminder24hAt = booking.Slot.StartTime.ToUniversalTime().AddHours(-24);
-            var reminder2hAt = booking.Slot.StartTime.ToUniversalTime().AddHours(-2);
-            var reminder24hJobId = _bookingScheduler.ScheduleAttendanceCheck(
-                telegramResult.ChatId,
-                telegramResult.MessageId,
-                booking.Slot.StartTime.ToUniversalTime(),
-                AttendanceReminderUseCase.ReminderType24h,
-                reminder24hAt);
-            var activeAfter24hSchedule = await _bookingCancellationLinkRepository.SaveReminderJobIdAsync(
-                telegramResult.ChatId,
-                telegramResult.MessageId,
-                AttendanceReminderUseCase.ReminderType24h,
-                reminder24hJobId,
-                cancellationToken);
-            if (!activeAfter24hSchedule)
-                _bookingScheduler.DeleteAttendanceCheck(reminder24hJobId);
-
-            var reminder2hJobId = _bookingScheduler.ScheduleAttendanceCheck(
-                telegramResult.ChatId,
-                telegramResult.MessageId,
-                booking.Slot.StartTime.ToUniversalTime(),
-                AttendanceReminderUseCase.ReminderType2h,
-                reminder2hAt);
-            var activeAfter2hSchedule = await _bookingCancellationLinkRepository.SaveReminderJobIdAsync(
-                telegramResult.ChatId,
-                telegramResult.MessageId,
-                AttendanceReminderUseCase.ReminderType2h,
-                reminder2hJobId,
-                cancellationToken);
-            if (!activeAfter2hSchedule)
-                _bookingScheduler.DeleteAttendanceCheck(reminder2hJobId);
+            await HandleBookingSucceededAsync(booking, bookResult, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -118,6 +60,168 @@ public sealed class ExecuteBookingUseCase
             _logger.LogError(ex, "Booking execution failed for key {BookingKey}; dedup key released", bookingKey);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Sends a single booking POST as part of a burst of concurrent attempts. Returns true if a
+    /// booking now exists for this slot (this attempt succeeded, or a sibling attempt already won and
+    /// is running the follow-ups). Returns false — without throwing — for the expected rejections a
+    /// burst produces (a request that arrived before the slot opened, or lost the race to a conflict),
+    /// so the caller can keep trying or stop. The success follow-ups run exactly once, latched on the
+    /// deduplication store at success time rather than at attempt time, so sibling shots never block
+    /// each other from firing.
+    /// </summary>
+    /// <summary>
+    /// Sends one booking POST as part of a burst. <paramref name="sendToken"/> governs only the POST
+    /// (so a sibling win or the burst hard-stop can abort an in-flight send); the success follow-ups run
+    /// on <paramref name="followUpToken"/> instead, so they are never cut off by the burst deadline.
+    /// <paramref name="onBooked"/> is invoked the instant this shot claims the slot — before the slower
+    /// follow-ups — so the remaining shots are stopped immediately. Returns true if a booking now exists
+    /// for this slot; false only for an expected/failed attempt. Never throws (except nothing — even a
+    /// failed follow-up is swallowed, because the booking already exists on Skedda).
+    /// </summary>
+    public async Task<bool> TryBookOnceAsync(
+        PreparedBooking booking,
+        int offsetMs,
+        CancellationToken sendToken,
+        CancellationToken followUpToken,
+        Action? onBooked = null)
+    {
+        SkeddaBookingResult bookResult;
+        try
+        {
+            bookResult = await _skeddaClient.BookAsync(booking, sendToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (SkeddaBookingRejectedException ex)
+        {
+            // Expected: this shot lost the race or arrived before the slot opened.
+            _logger.LogInformation(
+                "Burst shot at offset {OffsetMs} ms was rejected (expected) for user {Username}, slot {SlotStart}: {Reason}",
+                offsetMs,
+                booking.UserConfig.Username,
+                booking.Slot.StartTime,
+                ex.Message);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            // Unexpected: auth failure, 5xx, TLS, malformed response — a real regression, not a lost race.
+            _logger.LogWarning(
+                ex,
+                "Burst shot at offset {OffsetMs} ms failed unexpectedly for user {Username}, slot {SlotStart}",
+                offsetMs,
+                booking.UserConfig.Username,
+                booking.Slot.StartTime);
+            return false;
+        }
+
+        var bookingKey = BuildBookingKey(booking);
+        if (!_deduplicationStore.TryBegin(bookingKey))
+        {
+            // Another shot already claimed the slot. This shot's POST also succeeded, so a second
+            // booking may now exist on Skedda that we do not track — surface it loudly.
+            _logger.LogWarning(
+                "Burst shot at offset {OffsetMs} ms also booked slot (id {SkeddaBookingId}) but another shot already claimed {BookingKey}; this duplicate booking is untracked (no cancellation link/reminders)",
+                offsetMs,
+                bookResult.BookingId,
+                bookingKey);
+            return true;
+        }
+
+        // Slot is ours. Stop the remaining shots NOW, before the (slower) follow-ups run.
+        onBooked?.Invoke();
+        _logger.LogInformation(
+            "Burst shot at offset {OffsetMs} ms won the booking for user {Username}, slot {SlotStart}",
+            offsetMs,
+            booking.UserConfig.Username,
+            booking.Slot.StartTime);
+
+        try
+        {
+            await HandleBookingSucceededAsync(booking, bookResult, followUpToken);
+        }
+        catch (Exception ex)
+        {
+            // The booking exists on Skedda; a follow-up failure must not lose it, fault the burst, or
+            // release the dedup latch (releasing would make the +3s fallback re-POST into a conflict).
+            _logger.LogError(
+                ex,
+                "Booking {SkeddaBookingId} succeeded but follow-ups failed for {BookingKey}; booking exists but notification/cancellation link/reminders may be incomplete",
+                bookResult.BookingId,
+                bookingKey);
+        }
+
+        return true;
+    }
+
+    private async Task HandleBookingSucceededAsync(
+        PreparedBooking booking,
+        SkeddaBookingResult bookResult,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Skedda booking created with id {SkeddaBookingId}", bookResult.BookingId);
+
+        var telegramResult = await _notificationSender.NotifyBookingSucceededAsync(booking.UserConfig, booking.Slot, cancellationToken);
+        _logger.LogInformation(
+            "Telegram success notification sent: chat {ChatId}, message {MessageId}",
+            telegramResult.ChatId,
+            telegramResult.MessageId);
+
+        if (telegramResult.ChatId == 0 || telegramResult.MessageId == 0)
+        {
+            _logger.LogWarning(
+                "Skipping Telegram cancellation link and attendance reminders because no Telegram message was sent");
+            return;
+        }
+
+        await _bookingCancellationLinkRepository.SaveAsync(
+            booking.UserConfig,
+            booking.Slot,
+            telegramResult.ChatId,
+            telegramResult.MessageId,
+            bookResult.BookingId,
+            cancellationToken);
+        _logger.LogInformation(
+            "Stored cancellation link: chat {ChatId}, message {MessageId}, booking {SkeddaBookingId}",
+            telegramResult.ChatId,
+            telegramResult.MessageId,
+            bookResult.BookingId);
+
+        var reminder24hAt = booking.Slot.StartTime.ToUniversalTime().AddHours(-24);
+        var reminder2hAt = booking.Slot.StartTime.ToUniversalTime().AddHours(-2);
+        var reminder24hJobId = _bookingScheduler.ScheduleAttendanceCheck(
+            telegramResult.ChatId,
+            telegramResult.MessageId,
+            booking.Slot.StartTime.ToUniversalTime(),
+            AttendanceReminderUseCase.ReminderType24h,
+            reminder24hAt);
+        var activeAfter24hSchedule = await _bookingCancellationLinkRepository.SaveReminderJobIdAsync(
+            telegramResult.ChatId,
+            telegramResult.MessageId,
+            AttendanceReminderUseCase.ReminderType24h,
+            reminder24hJobId,
+            cancellationToken);
+        if (!activeAfter24hSchedule)
+            _bookingScheduler.DeleteAttendanceCheck(reminder24hJobId);
+
+        var reminder2hJobId = _bookingScheduler.ScheduleAttendanceCheck(
+            telegramResult.ChatId,
+            telegramResult.MessageId,
+            booking.Slot.StartTime.ToUniversalTime(),
+            AttendanceReminderUseCase.ReminderType2h,
+            reminder2hAt);
+        var activeAfter2hSchedule = await _bookingCancellationLinkRepository.SaveReminderJobIdAsync(
+            telegramResult.ChatId,
+            telegramResult.MessageId,
+            AttendanceReminderUseCase.ReminderType2h,
+            reminder2hJobId,
+            cancellationToken);
+        if (!activeAfter2hSchedule)
+            _bookingScheduler.DeleteAttendanceCheck(reminder2hJobId);
     }
 
     private static string BuildBookingKey(PreparedBooking booking)

--- a/src/TennisBooking.Infrastructure/Scheduling/PreciseBookingScheduler.cs
+++ b/src/TennisBooking.Infrastructure/Scheduling/PreciseBookingScheduler.cs
@@ -1,29 +1,48 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using TennisBooking.Application.Abstractions;
 using TennisBooking.Application.Booking;
+using TennisBooking.Options;
 
 namespace TennisBooking.Infrastructure.Scheduling;
 
 public sealed class PreciseBookingScheduler : IPreciseBookingScheduler, IHostedService, IDisposable
 {
-    private static readonly TimeSpan WarmupBeforeTarget = TimeSpan.FromSeconds(2);
-    private static readonly TimeSpan PrecisionStep = TimeSpan.FromMilliseconds(20);
-    // A stalled warm-up must never delay the POST: abandon it this far before the target instant.
+    // Begin warming this far ahead, so a failed probe has time to retry and the socket is proven warm
+    // well before the instant (a cold TCP+TLS to Skedda costs 1-2 s).
+    private static readonly TimeSpan WarmupLeadTime = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan WarmupRetryDelay = TimeSpan.FromMilliseconds(500);
+    // Once warm, re-ping at this cadence to keep the connection alive up to the deadline.
+    private static readonly TimeSpan WarmupKeepAliveInterval = TimeSpan.FromSeconds(2);
+    // A stalled warm-up must never delay the POST: stop warming this far before the target instant.
     private static readonly TimeSpan WarmupDeadlineMargin = TimeSpan.FromMilliseconds(300);
+    // Above this measured (coarse) skew, warn that the host clock likely needs NTP attention.
+    private const double GrossClockSkewWarnMs = 2000;
+
+    // Single source of the burst defaults, used when config supplies none. Kept in sync with the
+    // documented values (the SkeddaOptions properties default to empty so config can override cleanly).
+    private static readonly int[] DefaultBurstOffsetsMs = { -90, -60, -30, 0 };
+    private const int DefaultBurstStopAfterMs = 1500;
 
     private readonly ConcurrentDictionary<string, byte> _scheduled = new();
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly SkeddaOptions _options;
     private readonly ILogger<PreciseBookingScheduler> _logger;
     private readonly CancellationTokenSource _stoppingCts = new();
     private int _disposeState;
 
-    public PreciseBookingScheduler(IServiceScopeFactory scopeFactory, ILogger<PreciseBookingScheduler> logger)
+    public PreciseBookingScheduler(
+        IServiceScopeFactory scopeFactory,
+        IOptions<SkeddaOptions> options,
+        ILogger<PreciseBookingScheduler> logger)
     {
         _scopeFactory = scopeFactory;
+        _options = options.Value;
         _logger = logger;
     }
 
@@ -52,46 +71,24 @@ public sealed class PreciseBookingScheduler : IPreciseBookingScheduler, IHostedS
         try
         {
             var targetTime = booking.Slot.BookingOpensAt.ToUniversalTime();
-            var warmupTime = targetTime - WarmupBeforeTarget;
-            var now = DateTimeOffset.UtcNow;
-
             using var scope = _scopeFactory.CreateScope();
+            var skeddaClient = scope.ServiceProvider.GetRequiredService<ISkeddaClient>();
 
-            if (warmupTime > now)
-            {
-                await Task.Delay(warmupTime - now, token);
-                // Pre-open the pooled TCP+TLS connection so the POST below reuses a warm socket.
-                // Bound it to a deadline before the target so a slow probe can't delay the POST.
-                var remainingToDeadline = (targetTime - WarmupDeadlineMargin) - DateTimeOffset.UtcNow;
-                if (remainingToDeadline > TimeSpan.Zero)
-                {
-                    using var warmupCts = CancellationTokenSource.CreateLinkedTokenSource(token);
-                    warmupCts.CancelAfter(remainingToDeadline);
-                    var skeddaClient = scope.ServiceProvider.GetRequiredService<ISkeddaClient>();
-                    try
-                    {
-                        await skeddaClient.WarmupAsync(booking, warmupCts.Token);
-                    }
-                    catch (OperationCanceledException) when (!token.IsCancellationRequested)
-                    {
-                        _logger.LogWarning(
-                            "Skedda warm-up exceeded its deadline for {Key}; proceeding without a pre-warmed connection",
-                            key);
-                    }
-                }
-            }
-
-            while (DateTimeOffset.UtcNow < targetTime)
-            {
-                var remaining = targetTime - DateTimeOffset.UtcNow;
-                var delay = remaining > PrecisionStep ? PrecisionStep : remaining;
-                if (delay > TimeSpan.Zero)
-                    await Task.Delay(delay, token);
-            }
+            // Keep a connection proven-warm right up to the instant. The warm-up also measures the
+            // host<->Skedda clock skew, but that is LOGGING-ONLY and never shifts the fire time: the
+            // Date header is second-resolution, so a correct local clock can still show up to ~1s of
+            // apparent skew (quantization) — larger than the tuned offsets, so correcting on it would
+            // hurt. Keep the host clock NTP-synced; we only surface a grossly wrong clock to fix at OS level.
+            await EnsureWarmConnectionAsync(skeddaClient, booking, targetTime, key, token);
 
             var executeBooking = scope.ServiceProvider.GetRequiredService<ExecuteBookingUseCase>();
-            await executeBooking.ExecuteAsync(booking, token);
-            _logger.LogInformation("Precise timer triggered booking for {Username} at {Target}", booking.UserConfig.Username, targetTime);
+            var booked = await RunBookingBurstAsync(executeBooking, booking, targetTime, token);
+            if (booked)
+                _logger.LogInformation("Precise burst booked slot for {Username} at {Target}", booking.UserConfig.Username, targetTime);
+            else if (token.IsCancellationRequested)
+                _logger.LogInformation("Precise burst cancelled during shutdown for {Key}", key);
+            else
+                _logger.LogWarning("Precise burst exhausted without booking for {Key}", key);
         }
         catch (OperationCanceledException)
         {
@@ -104,6 +101,139 @@ public sealed class PreciseBookingScheduler : IPreciseBookingScheduler, IHostedS
         finally
         {
             _scheduled.TryRemove(key, out _);
+        }
+    }
+
+    // Warm the pooled connection from WarmupLeadTime before the instant, retrying on failure and
+    // re-pinging to keep it alive, until WarmupDeadlineMargin before the target. Returns the freshest
+    // estimated host->server clock skew (or null). A cold connection at the instant costs 1-2 s, so
+    // this exists to make the booking POST never pay that handshake.
+    private async Task EnsureWarmConnectionAsync(
+        ISkeddaClient skeddaClient,
+        PreparedBooking booking,
+        DateTimeOffset targetTime,
+        string key,
+        CancellationToken token)
+    {
+        var deadline = targetTime - WarmupDeadlineMargin;
+        var warmStart = targetTime - WarmupLeadTime;
+        var now = DateTimeOffset.UtcNow;
+        if (warmStart > now)
+            await Task.Delay(warmStart - now, token);
+
+        var established = false;
+        TimeSpan? skew = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var remaining = deadline - DateTimeOffset.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            SkeddaWarmupResult result;
+            using (var warmupCts = CancellationTokenSource.CreateLinkedTokenSource(token))
+            {
+                warmupCts.CancelAfter(remaining);
+                try
+                {
+                    result = await skeddaClient.WarmupAsync(booking, warmupCts.Token);
+                }
+                catch (OperationCanceledException) when (!token.IsCancellationRequested)
+                {
+                    break; // hit the warm-up deadline; leave time for the burst
+                }
+            }
+
+            if (result.Established)
+            {
+                established = true;
+                if (result.ClockSkew is { } s)
+                    skew = s;
+            }
+
+            var pause = result.Established ? WarmupKeepAliveInterval : WarmupRetryDelay;
+            if (DateTimeOffset.UtcNow + pause >= deadline)
+                break;
+            await Task.Delay(pause, token);
+        }
+
+        if (!established)
+            _logger.LogWarning(
+                "Skedda connection not confirmed warm before open for {Key}; a shot may pay a cold handshake",
+                key);
+        if (skew is { } sk)
+        {
+            _logger.LogInformation(
+                "Estimated host->Skedda clock skew {SkewMs:F0} ms for {Key} (Date-header resolution ~1 s; not used to shift fire time)",
+                sk.TotalMilliseconds,
+                key);
+            if (Math.Abs(sk.TotalMilliseconds) >= GrossClockSkewWarnMs)
+                _logger.LogWarning(
+                    "Host clock appears ~{SkewMs:F0} ms off Skedda's for {Key}; check NTP/chrony — the burst relies on an accurate local clock",
+                    sk.TotalMilliseconds,
+                    key);
+        }
+    }
+
+    // Fire the same booking several times at configured offsets around the open instant so that,
+    // despite a jittery connection, at least one request LANDS as the slot opens. Stop as soon as one
+    // attempt succeeds; abandon the rest once the slot is realistically gone.
+    private async Task<bool> RunBookingBurstAsync(
+        ExecuteBookingUseCase executeBooking,
+        PreparedBooking booking,
+        DateTimeOffset targetTime,
+        CancellationToken followUpToken)
+    {
+        var offsetsMs = (_options.BookingSendOffsetsMs is { Length: > 0 } configured ? configured : DefaultBurstOffsetsMs)
+            .Distinct()
+            .OrderBy(ms => ms)
+            .ToArray();
+        var stopAfterMs = _options.BookingSendStopAfterMs > 0 ? _options.BookingSendStopAfterMs : DefaultBurstStopAfterMs;
+
+        using var burstCts = CancellationTokenSource.CreateLinkedTokenSource(followUpToken);
+        var hardStopIn = targetTime + TimeSpan.FromMilliseconds(stopAfterMs) - DateTimeOffset.UtcNow;
+        if (hardStopIn <= TimeSpan.Zero)
+        {
+            // Woke up after the whole burst window already elapsed (GC pause, load, clock step). Fire one
+            // immediate best-effort attempt rather than giving up with zero POSTs, as the old code did.
+            _logger.LogWarning(
+                "Burst woke {LateMs:F0} ms after open for user {Username}; firing one immediate attempt",
+                -hardStopIn.TotalMilliseconds,
+                booking.UserConfig.Username);
+            return await executeBooking.TryBookOnceAsync(booking, 0, followUpToken, followUpToken);
+        }
+        burstCts.CancelAfter(hardStopIn);
+
+        var shots = offsetsMs
+            .Select(offsetMs => FireShotAsync(executeBooking, booking, targetTime, offsetMs, burstCts, followUpToken))
+            .ToArray();
+        var results = await Task.WhenAll(shots);
+        return results.Any(success => success);
+    }
+
+    private async Task<bool> FireShotAsync(
+        ExecuteBookingUseCase executeBooking,
+        PreparedBooking booking,
+        DateTimeOffset targetTime,
+        int offsetMs,
+        CancellationTokenSource burstCts,
+        CancellationToken followUpToken)
+    {
+        try
+        {
+            var wait = targetTime + TimeSpan.FromMilliseconds(offsetMs) - DateTimeOffset.UtcNow;
+            if (wait > TimeSpan.Zero)
+                await Task.Delay(wait, burstCts.Token);
+
+            // Send on the burst token (abortable by a sibling win or the hard stop); run the success
+            // follow-ups on the outer token; and stop the remaining shots the instant this one claims
+            // the slot — before those (slower) follow-ups run.
+            return await executeBooking.TryBookOnceAsync(
+                booking, offsetMs, burstCts.Token, followUpToken, () => burstCts.Cancel());
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancelled because a sibling shot already booked the slot, or the hard-stop deadline hit.
+            return false;
         }
     }
 

--- a/src/TennisBooking.Infrastructure/Skedda/SkeddaClient.cs
+++ b/src/TennisBooking.Infrastructure/Skedda/SkeddaClient.cs
@@ -83,7 +83,19 @@ public sealed class SkeddaClient : ISkeddaClient
 
         var bookResp = await client.SendAsync(bookReq, cancellationToken);
         if (!bookResp.IsSuccessStatusCode)
-            throw new HttpRequestException($"Response from Skedda {await bookResp.Content.ReadAsStringAsync(cancellationToken)}");
+        {
+            var status = (int)bookResp.StatusCode;
+            var errorBody = await bookResp.Content.ReadAsStringAsync(cancellationToken);
+            // A client-side business rejection (slot already taken, not open yet, validation) is an
+            // expected race outcome and comes back as a NON-auth 4xx. Authentication (401/403), rate
+            // limiting (429) and server errors (5xx) are real failures the caller must not mistake for
+            // a normal lost race — regardless of what the response body happens to contain.
+            var expectedRejection = status is >= 400 and < 500
+                && status is not 401 and not 403 and not 429;
+            if (expectedRejection)
+                throw new SkeddaBookingRejectedException(status, errorBody);
+            throw new HttpRequestException($"Skedda booking failed with status {status}: {errorBody}");
+        }
 
         var body = await bookResp.Content.ReadAsStringAsync(cancellationToken);
         dynamic? json = JsonConvert.DeserializeObject(body);
@@ -95,31 +107,36 @@ public sealed class SkeddaClient : ISkeddaClient
         return new SkeddaBookingResult(bookingId);
     }
 
-    public async Task WarmupAsync(PreparedBooking booking, CancellationToken cancellationToken)
+    public async Task<SkeddaWarmupResult> WarmupAsync(PreparedBooking booking, CancellationToken cancellationToken)
     {
         // Issue a cheap UNAUTHENTICATED GET on the pooled client during the pre-warm window so the
         // TCP+TLS handshake (and Front Door edge routing) completes ahead of the target instant,
         // letting the booking POST reuse an already-established connection. Warming the socket does
-        // not need the session, so we deliberately do NOT replay the CSRF/cookie headers here:
-        // that avoids touching the antiforgery-token page and minimizes anomalous request surface.
+        // not need the session, so we deliberately do NOT replay the CSRF/cookie headers here.
         // ResponseHeadersRead returns as soon as the connection is established and headers arrive.
+        // We also read the server Date header to estimate the host<->Skedda clock skew.
         // Best-effort: never throws except on cancellation.
         try
         {
             var client = _httpClientFactory.CreateClient(SkeddaHttpClientName);
             using var warmReq = new HttpRequestMessage(HttpMethod.Get, AccountLoginPath);
+            var sentAt = DateTimeOffset.UtcNow;
             using var warmResp = await client.SendAsync(
                 warmReq, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            if (warmResp.IsSuccessStatusCode)
-                _logger.LogInformation(
-                    "Warmed up Skedda connection for user {Username} (status {StatusCode})",
-                    booking.UserConfig.Username,
-                    (int)warmResp.StatusCode);
-            else
-                _logger.LogWarning(
-                    "Skedda warm-up GET returned {StatusCode} for user {Username}",
-                    (int)warmResp.StatusCode,
-                    booking.UserConfig.Username);
+            var roundTrip = DateTimeOffset.UtcNow - sentAt;
+
+            TimeSpan? skew = warmResp.Headers.Date is { } serverDate
+                ? EstimateClockSkew(serverDate, sentAt, roundTrip)
+                : null;
+
+            _logger.LogInformation(
+                "Warmed up Skedda connection for user {Username} (status {StatusCode}, rtt {RttMs:F0} ms, skew {SkewMs})",
+                booking.UserConfig.Username,
+                (int)warmResp.StatusCode,
+                roundTrip.TotalMilliseconds,
+                skew?.TotalMilliseconds.ToString("F0") ?? "n/a");
+            // Any completed response means the connection is warm, even a non-2xx.
+            return new SkeddaWarmupResult(Established: true, ClockSkew: skew);
         }
         catch (OperationCanceledException)
         {
@@ -131,8 +148,17 @@ public sealed class SkeddaClient : ISkeddaClient
                 ex,
                 "Skedda connection warm-up failed for user {Username}; proceeding without a pre-warmed connection",
                 booking.UserConfig.Username);
+            return new SkeddaWarmupResult(Established: false, ClockSkew: null);
         }
     }
+
+    /// <summary>
+    /// Estimate the server-minus-host clock offset from a response Date header: the server stamped
+    /// <paramref name="serverDate"/> roughly half a round-trip after we sent, so we compare it to our
+    /// clock at that same midpoint. Coarse (Date is second-resolution). Exposed for testing.
+    /// </summary>
+    public static TimeSpan EstimateClockSkew(DateTimeOffset serverDate, DateTimeOffset sentAtUtc, TimeSpan roundTrip)
+        => serverDate - (sentAtUtc + TimeSpan.FromTicks(roundTrip.Ticks / 2));
 
     public async Task CancelAsync(PreparedBooking booking, string bookingId, CancellationToken cancellationToken)
     {

--- a/src/TennisBooking.Infrastructure/Skedda/SkeddaOptions.cs
+++ b/src/TennisBooking.Infrastructure/Skedda/SkeddaOptions.cs
@@ -3,4 +3,25 @@ namespace TennisBooking.Options;
 public class SkeddaOptions
 {
     public string ApiBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Booking POST burst: the same booking is fired several times at these offsets (milliseconds)
+    /// relative to the exact open instant, so that — despite a jittery residential connection — at
+    /// least one request LANDS right as the slot opens. Negative = before open (compensates for the
+    /// network flight time), positive = after. The burst stops as soon as one attempt succeeds. A
+    /// single offset of 0 reproduces the original single-shot behaviour.
+    ///
+    /// Defaults to empty on purpose: the .NET configuration binder APPENDS bound array items to a
+    /// non-empty default, which would make the value un-tunable. Empty here means a configured value
+    /// fully replaces it, and when none is configured the scheduler falls back to its own defaults
+    /// (PreciseBookingScheduler.DefaultBurstOffsetsMs) — the single source of the real defaults.
+    /// </summary>
+    public int[] BookingSendOffsetsMs { get; set; } = Array.Empty<int>();
+
+    /// <summary>
+    /// Deadline for the burst SEND window, measured from the open instant: an attempt whose POST is
+    /// still in flight past this point is abandoned. Follow-ups (notification/DB/reminders) run outside
+    /// this deadline. 0 means "use the scheduler default" (see PreciseBookingScheduler.DefaultBurstStopAfterMs).
+    /// </summary>
+    public int BookingSendStopAfterMs { get; set; }
 }

--- a/src/TennisBooking/Program.cs
+++ b/src/TennisBooking/Program.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Security;
 using System.Net.Sockets;
 using Hangfire;
 using Hangfire.PostgreSql;
@@ -39,7 +40,9 @@ builder.Services.AddHttpClient(SkeddaClient.SkeddaHttpClientName, (sp, client) =
     {
         var opts = sp.GetRequiredService<IOptions<SkeddaOptions>>().Value;
         client.BaseAddress = new Uri(opts.ApiBaseUrl);
-        // Opportunistically negotiate HTTP/2 via ALPN; silently falls back to HTTP/1.1.
+        // Request HTTP/2; the handler negotiates it via ALPN (configured in SslOptions below), and
+        // falls back to HTTP/1.1 if the origin ever stops offering h2. Under h2 the burst's concurrent
+        // POSTs multiplex over a single warm connection.
         client.DefaultRequestVersion = HttpVersion.Version20;
         client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
     })
@@ -54,11 +57,25 @@ builder.Services.AddHttpClient(SkeddaClient.SkeddaHttpClientName, (sp, client) =
         // pick up Front Door DNS/IP changes.
         PooledConnectionLifetime = TimeSpan.FromMinutes(10),
         PooledConnectionIdleTimeout = TimeSpan.FromMinutes(5),
-        // Headroom so concurrent same-window bookings (one warm-up + POST each) never queue for a
-        // connection under an HTTP/1.1 fallback; free under HTTP/2 where a connection multiplexes.
+        // Headroom so concurrent same-window bookings never queue for a connection under an HTTP/1.1
+        // fallback; free under HTTP/2 where a connection multiplexes.
         MaxConnectionsPerServer = 10,
         EnableMultipleHttp2Connections = true,
-        // Disable Nagle's algorithm (TCP_NODELAY) so the small booking POST is flushed immediately.
+        // Offer h2 (then http/1.1) via ALPN. The handler performs TLS itself over the transport stream
+        // returned by ConnectCallback and honours these protocols, so the connection negotiates HTTP/2
+        // deterministically (verified against galaktyka.skedda.com); default server-cert validation and
+        // SNI are applied automatically. Setting the request version alone is NOT enough here — a custom
+        // ConnectCallback otherwise leaves the handshake at the runtime default (HTTP/1.1 in production).
+        SslOptions = new SslClientAuthenticationOptions
+        {
+            ApplicationProtocols = new List<SslApplicationProtocol>
+            {
+                SslApplicationProtocol.Http2,
+                SslApplicationProtocol.Http11
+            }
+        },
+        // Return a plain connected transport stream with Nagle's algorithm disabled (TCP_NODELAY) so the
+        // small booking POST is flushed immediately; the handler layers TLS (with the ALPN above) on top.
         ConnectCallback = async (context, cancellationToken) =>
         {
             var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };

--- a/src/TennisBooking/appsettings.json
+++ b/src/TennisBooking/appsettings.json
@@ -1,6 +1,8 @@
 ﻿{
   "SkeddaConfig": {
-    "ApiBaseUrl": "https://galaktyka.skedda.com"
+    "ApiBaseUrl": "https://galaktyka.skedda.com",
+    "BookingSendOffsetsMs": [ -90, -60, -30, 0 ],
+    "BookingSendStopAfterMs": 1500
   },
   "ConnectionStrings": {
     "Default": "Host=localhost;Port=5432;Database=tennis_db;Username=postgres;Password=blabla;Pooling=true;Minimum Pool Size=0;Maximum Pool Size=20;Timeout=15;"

--- a/tests/TennisBooking.Tests/UnitTests.cs
+++ b/tests/TennisBooking.Tests/UnitTests.cs
@@ -90,6 +90,166 @@ public class UnitTests
     }
 
     [Fact]
+    public async Task TryBookOnce_Succeeds_RunsFollowUpsExactlyOnce_AcrossBurstShots()
+    {
+        var skedda = new Mock<ISkeddaClient>();
+        skedda.Setup(x => x.BookAsync(It.IsAny<PreparedBooking>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SkeddaBookingResult("1"));
+        var notification = new Mock<INotificationSender>();
+        notification.Setup(x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TelegramNotificationResult(5, 10));
+        var useCase = new ExecuteBookingUseCase(
+            skedda.Object,
+            notification.Object,
+            new InMemoryBookingDeduplicationStore(),
+            Mock.Of<IBookingCancellationLinkRepository>(),
+            Mock.Of<IBookingScheduler>(),
+            NullLogger<ExecuteBookingUseCase>.Instance);
+        var booking = Prepared(BasicDomainConfig(), new BookingSlot(new DateTimeOffset(2030, 6, 15, 10, 0, 0, TimeSpan.Zero)));
+
+        // Two sequential burst shots that both reach Skedda successfully.
+        var first = await useCase.TryBookOnceAsync(booking, -60, CancellationToken.None, CancellationToken.None);
+        var second = await useCase.TryBookOnceAsync(booking, -30, CancellationToken.None, CancellationToken.None);
+
+        Assert.True(first);
+        Assert.True(second);
+        skedda.Verify(x => x.BookAsync(booking, It.IsAny<CancellationToken>()), Times.Exactly(2));
+        // Follow-ups (notification, reminders, cancellation link) run once even if two shots succeed.
+        notification.Verify(x => x.NotifyBookingSucceededAsync(booking.UserConfig, booking.Slot, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TryBookOnce_ReturnsFalseWithoutThrowing_WhenSkeddaRejects()
+    {
+        var skedda = new Mock<ISkeddaClient>();
+        skedda.Setup(x => x.BookAsync(It.IsAny<PreparedBooking>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SkeddaBookingRejectedException(409, "conflicts with one already scheduled"));
+        var notification = new Mock<INotificationSender>();
+        var useCase = new ExecuteBookingUseCase(
+            skedda.Object,
+            notification.Object,
+            new InMemoryBookingDeduplicationStore(),
+            Mock.Of<IBookingCancellationLinkRepository>(),
+            Mock.Of<IBookingScheduler>(),
+            NullLogger<ExecuteBookingUseCase>.Instance);
+        var booking = Prepared(BasicDomainConfig(), new BookingSlot(new DateTimeOffset(2030, 6, 15, 10, 0, 0, TimeSpan.Zero)));
+
+        var result = await useCase.TryBookOnceAsync(booking, -30, CancellationToken.None, CancellationToken.None);
+
+        Assert.False(result);
+        notification.Verify(
+            x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryBookOnce_LaterShotSucceeds_AfterEarlierShotRejected()
+    {
+        var skedda = new Mock<ISkeddaClient>();
+        skedda.SetupSequence(x => x.BookAsync(It.IsAny<PreparedBooking>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SkeddaBookingRejectedException(422, "slot not open yet"))
+            .ReturnsAsync(new SkeddaBookingResult("1"));
+        var notification = new Mock<INotificationSender>();
+        notification.Setup(x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TelegramNotificationResult(5, 10));
+        var useCase = new ExecuteBookingUseCase(
+            skedda.Object,
+            notification.Object,
+            new InMemoryBookingDeduplicationStore(),
+            Mock.Of<IBookingCancellationLinkRepository>(),
+            Mock.Of<IBookingScheduler>(),
+            NullLogger<ExecuteBookingUseCase>.Instance);
+        var booking = Prepared(BasicDomainConfig(), new BookingSlot(new DateTimeOffset(2030, 6, 15, 10, 0, 0, TimeSpan.Zero)));
+
+        // An early shot that lands before the slot opens must not consume the success latch.
+        Assert.False(await useCase.TryBookOnceAsync(booking, -90, CancellationToken.None, CancellationToken.None));
+        Assert.True(await useCase.TryBookOnceAsync(booking, -30, CancellationToken.None, CancellationToken.None));
+        notification.Verify(x => x.NotifyBookingSucceededAsync(booking.UserConfig, booking.Slot, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TryBookOnce_ConcurrentShots_RunFollowUpsExactlyOnce()
+    {
+        var skedda = new Mock<ISkeddaClient>();
+        var bookCalls = 0;
+        skedda.Setup(x => x.BookAsync(It.IsAny<PreparedBooking>(), It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                Interlocked.Increment(ref bookCalls);
+                await Task.Delay(25); // let all shots clear BookAsync before any claims the latch
+                return new SkeddaBookingResult("1");
+            });
+        var notification = new Mock<INotificationSender>();
+        notification.Setup(x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TelegramNotificationResult(5, 10));
+        var useCase = new ExecuteBookingUseCase(
+            skedda.Object,
+            notification.Object,
+            new InMemoryBookingDeduplicationStore(),
+            Mock.Of<IBookingCancellationLinkRepository>(),
+            Mock.Of<IBookingScheduler>(),
+            NullLogger<ExecuteBookingUseCase>.Instance);
+        var booking = Prepared(BasicDomainConfig(), new BookingSlot(new DateTimeOffset(2030, 6, 15, 10, 0, 0, TimeSpan.Zero)));
+
+        // Fire four shots concurrently, the way the burst actually invokes them.
+        var results = await Task.WhenAll(new[] { -90, -60, -30, 0 }.Select(o =>
+            useCase.TryBookOnceAsync(booking, o, CancellationToken.None, CancellationToken.None)));
+
+        Assert.All(results, Assert.True);
+        Assert.Equal(4, bookCalls);
+        // Exactly one shot wins the latch and runs the follow-ups no matter how the four race.
+        notification.Verify(x => x.NotifyBookingSucceededAsync(booking.UserConfig, booking.Slot, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TryBookOnce_FollowUpFailure_StillReportsBookingAndDoesNotThrow()
+    {
+        var skedda = new Mock<ISkeddaClient>();
+        skedda.Setup(x => x.BookAsync(It.IsAny<PreparedBooking>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SkeddaBookingResult("1"));
+        var notification = new Mock<INotificationSender>();
+        notification.Setup(x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("telegram down"));
+        var useCase = new ExecuteBookingUseCase(
+            skedda.Object,
+            notification.Object,
+            new InMemoryBookingDeduplicationStore(),
+            Mock.Of<IBookingCancellationLinkRepository>(),
+            Mock.Of<IBookingScheduler>(),
+            NullLogger<ExecuteBookingUseCase>.Instance);
+        var booking = Prepared(BasicDomainConfig(), new BookingSlot(new DateTimeOffset(2030, 6, 15, 10, 0, 0, TimeSpan.Zero)));
+
+        // The booking exists on Skedda; a follow-up failure must not throw or be reported as a miss.
+        var result = await useCase.TryBookOnceAsync(booking, 0, CancellationToken.None, CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task TryBookOnce_UnexpectedError_ReturnsFalseWithoutThrowing()
+    {
+        var skedda = new Mock<ISkeddaClient>();
+        skedda.Setup(x => x.BookAsync(It.IsAny<PreparedBooking>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Skedda booking failed with status 500"));
+        var notification = new Mock<INotificationSender>();
+        var useCase = new ExecuteBookingUseCase(
+            skedda.Object,
+            notification.Object,
+            new InMemoryBookingDeduplicationStore(),
+            Mock.Of<IBookingCancellationLinkRepository>(),
+            Mock.Of<IBookingScheduler>(),
+            NullLogger<ExecuteBookingUseCase>.Instance);
+        var booking = Prepared(BasicDomainConfig(), new BookingSlot(new DateTimeOffset(2030, 6, 15, 10, 0, 0, TimeSpan.Zero)));
+
+        var result = await useCase.TryBookOnceAsync(booking, 0, CancellationToken.None, CancellationToken.None);
+
+        Assert.False(result);
+        notification.Verify(
+            x => x.NotifyBookingSucceededAsync(It.IsAny<BookingUserConfig>(), It.IsAny<BookingSlot>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task ExecuteBooking_SkipsTelegramFollowUps_WhenNotificationWasNotSent()
     {
         var skedda = new Mock<ISkeddaClient>();
@@ -440,6 +600,39 @@ public class UnitTests
         await client.BookAsync(booking, CancellationToken.None);
 
         Assert.Equal(1, bookingPosts);
+    }
+
+    [Fact]
+    public void EstimateClockSkew_ComputesServerMinusHostAtRoundTripMidpoint()
+    {
+        var sentAt = new DateTimeOffset(2030, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var rtt = TimeSpan.FromMilliseconds(100);
+        // Server clock runs 2s ahead; it stamped Date at the round-trip midpoint (sentAt + 50ms).
+        var serverDate = sentAt + TimeSpan.FromMilliseconds(50) + TimeSpan.FromSeconds(2);
+
+        var skew = SkeddaClient.EstimateClockSkew(serverDate, sentAt, rtt);
+
+        Assert.True(Math.Abs(skew.TotalMilliseconds - 2000) < 1, $"expected ~+2000ms, got {skew.TotalMilliseconds}");
+    }
+
+    [Fact]
+    public async Task Warmup_AgainstServer_ReportsConnectionEstablished()
+    {
+        using var server = new FakeSkeddaServer();
+        server.Enqueue(HttpMethod.Get, "/account/login", ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            return "<html>ok</html>";
+        });
+        var client = new SkeddaClient(
+            new SingleClientHttpClientFactory(server.BaseUrl),
+            Microsoft.Extensions.Options.Options.Create(new SkeddaOptions { ApiBaseUrl = server.BaseUrl }),
+            NullLogger<SkeddaClient>.Instance);
+        var booking = Prepared(BasicDomainConfig(), new BookingSlot(DateTimeOffset.UtcNow));
+
+        var result = await client.WarmupAsync(booking, CancellationToken.None);
+
+        Assert.True(result.Established);
     }
 
     [Fact]


### PR DESCRIPTION
## What

- **Staggered burst** — fire the same booking as concurrent POSTs at configurable offsets `[-90,-60,-30,0]` ms around open, first-success-wins, `+1500 ms` hard stop. The `0` shot fires at open sharp as a guaranteed-valid backstop; the negatives prefire to land near open. Tunable via `SkeddaConfig`.
- **HTTP/2 to Skedda** — the pooled client was silently on HTTP/1.1 (a custom `ConnectCallback` returning a plain stream left the handshake at the runtime default). It now offers h2 via ALPN through `SocketsHttpHandler.SslOptions` while the callback returns a `NoDelay` transport stream; the handler performs TLS with default cert validation + SNI, and all shots multiplex over one warm connection. Verified end-to-end against `galaktyka.skedda.com` (h2, TLS 1.3).
- **Guaranteed warm connection** — warm from 10 s out, retry on failure, keep-alive ping until 300 ms before open, so a shot never pays the 1–2 s cold handshake.
- **Clock-skew: logging-only** — the warm-up samples Skedda's `Date` header and logs the estimated skew (and warns if the local clock looks grossly off), but does **not** shift the fire time — the header is 1 s-resolution, so correcting on it could move the burst ~1 s and hurt. Clock accuracy is left to NTP.
- **Error classification** — expected race rejections (non-auth 4xx) log at Info; auth (401/403), rate-limit (429) and 5xx log at Warning so real regressions surface.
- **Observability** — the winning burst offset is logged.

## Correctness (from multiple review rounds)

- Success follow-ups (Telegram/DB/reminders) run on the outer token, **not** the burst token, and are guarded — a slow-but-winning write is never cancelled by the hard stop, and a follow-up failure never loses the booking or faults the burst.
- Sibling shots are cancelled the instant a shot claims the slot (before follow-ups).
- Config arrays default to empty so appsettings values replace them cleanly (the .NET binder appends to non-empty defaults); the scheduler constants are the single source of defaults.
- A duplicate successful POST's booking id is logged at Warning rather than silently dropped.
- Late wakeup fires one immediate best-effort shot instead of giving up.
- The "double TLS" concern raised in review was checked empirically — both the SslStream-in-callback and the SslOptions approaches negotiate h2 with no double handshake; the PR ships the SslOptions form as the more idiomatic one.

## Testing

The test project is now part of the solution, so `dotnet test` runs it (previously it only built the app and ran zero tests). **31/31 unit tests pass**, incl. concurrent-race follow-up idempotency, follow-up-failure resilience, unexpected-error handling, clock-skew math, and warm-up establishment. Integration (`[DockerFact]`) needs Docker and isn't run here. Full solution builds with 0 warnings.

## Follow-ups (not in this PR)

- Read-only "fire-on-open" availability probe — pending capture of Skedda's real availability endpoint.
- Pre-existing DST bug in `BookingSlot.BookingOpensAt` (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
