### PR TITLE
Fix Docker build: restore app project, not the solution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,12 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 COPY Directory.Packages.props ./
-COPY TennisBooking.slnx ./
 COPY src/TennisBooking.Domain/TennisBooking.Domain.csproj src/TennisBooking.Domain/
 COPY src/TennisBooking.Application/TennisBooking.Application.csproj src/TennisBooking.Application/
 COPY src/TennisBooking.Infrastructure/TennisBooking.Infrastructure.csproj src/TennisBooking.Infrastructure/
 COPY src/TennisBooking/TennisBooking.csproj src/TennisBooking/
 
-RUN dotnet restore TennisBooking.slnx --disable-parallel
+RUN dotnet restore src/TennisBooking/TennisBooking.csproj --disable-parallel
 
 COPY . .
 RUN dotnet publish src/TennisBooking/TennisBooking.csproj -c Release -o /app/publish --no-restore


### PR DESCRIPTION
## Problem

The production Docker build fails at restore:

```
error MSB3202: The project file "/src/tests/TennisBooking.Tests/TennisBooking.Tests.csproj" was not found. [/src/TennisBooking.slnx]
```

PR #21 added the test project to `TennisBooking.slnx` so `dotnet test` runs it. But the Dockerfile restores the **solution** while only copying the **app** csprojs (the standard layer-caching pattern), so `dotnet restore TennisBooking.slnx` now demands the test csproj, which isn't copied.

## Fix

Restore the app project directly — `dotnet restore src/TennisBooking/TennisBooking.csproj` — which pulls in its transitive project references (Domain/Application/Infrastructure), all already copied. The `publish` step already targets the app project, and the production image never needs the test project. Also drops the now-unused `.slnx` COPY.

Verified locally: `dotnet publish src/TennisBooking/TennisBooking.csproj -c Release` succeeds against current master, and no app project references the test project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)